### PR TITLE
ES-887100 Revamp HTML conversion page with proper headings

### DIFF
--- a/Document-Processing/Word/Word-Library/NET/html.md
+++ b/Document-Processing/Word/Word-Library/NET/html.md
@@ -237,7 +237,7 @@ N> Calling the above event is mandatory in ASP.NET Core, UWP, and Xamarin platfo
 
 * [How to get image from URL while opening HTML in .NET Core targeting applications?](https://www.syncfusion.com/kb/13053/how-to-get-image-from-url-while-opening-html-in-asp-net-core)
 
-## Convert Word to html
+## Convert Word to HTML
 
 The following code example shows how to convert the Word document into HTML.
 


### PR DESCRIPTION
<table>
<tbody>
<tr >
<td>Task Link</td>
<td><p><a href="https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/887100/">https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/887100/</a></p></td>
</tr>
<tr>
<td>Description</td>
<td style="height: 72px; width: 779.275px;">
<p>Revamp HTML conversion page with proper headings</p>
</td>
</tr>
<tr>
<td>Solution</td>
<td>
<ol>
<li>Added second level heading "Convert Word to HTML" and "Convert HTML to Word"</li>
<li>Changed the hierarchy as per the suggestion</li>
</ol>
</td>
</tr>
</tbody>
</table>