### PR TITLE
889697: Conversion failed in Azure App Service when pushing via Azure Pipeline using the WebKit rendering engine.

### DIFF
--- a/Document-Processing/PDF/Conversions/HTML-To-PDF/NET/troubleshooting.md
+++ b/Document-Processing/PDF/Conversions/HTML-To-PDF/NET/troubleshooting.md
@@ -1023,3 +1023,82 @@ KB: [https://www.syncfusion.com/kb/10258/how-to-convert-html-to-pdf-in-azure-usi
 </tr>
 
 </table>
+
+## Conversion failed in Azure App Service when pushing via Azure Pipeline using the WebKit rendering engine.
+
+<table>
+<th style="font-size:14px" width="100px">Issue</th>
+<th style="font-size:14px">Conversion failed in Azure App Service when pushing via Azure Pipeline using the WebKit rendering engine.
+</th>
+<tr>
+<th style="font-size:14px" width="100px">Reason
+</th>
+<td>	
+The problem that was reported may be caused by using the Zip deploy method to publish the project. When the project is pushed, it will automatically utilize the zip deploy method within the Azure pipeline.
+
+</td>
+</tr>
+<tr>
+<th style="font-size:14px" width="100px">Solution</th>
+<td>
+We can resolve the reported issue by changing the deployment method to web deploy in the yml file. Please refer to the code snippet below.
+
+{% tabs %}
+{% highlight C# %}
+
+	trigger:
+
+	- main
+
+	pool:
+
+	vmImage: windows-latest
+
+	variables:
+
+	buildConfiguration: 'Release'
+
+	steps:
+
+	- script: dotnet build --configuration $(buildConfiguration)
+
+	displayName: 'dotnet build $(buildConfiguration)'
+
+	- task: DotNetCoreCLI@2
+
+	inputs:
+
+	command: 'publish'
+
+	publishWebProjects: true
+
+	arguments: '--configuration $(buildConfiguration)'
+
+	zipAfterPublish: true
+
+	- task: AzureRmWebAppDeployment@4
+
+	inputs:
+
+	ConnectionType: 'AzureRM'
+
+	azureSubscription: 'htmlconnection'
+
+	appType: 'webApp'
+
+	WebAppName: 'pipelineHtmlToPDF'
+
+	packageForLinux: '$(System.DefaultWorkingDirectory)/**/*.zip'
+
+	enableCustomDeployment: true
+
+	DeploymentType: 'webDeploy'
+
+
+	
+{% endhighlight %}
+{% endtabs %}
+</td>
+</tr>
+
+</table>


### PR DESCRIPTION
Hi team,

Here we added "Conversion failed in Azure App Service when pushing via Azure Pipeline using the WebKit rendering engine" in HTML to PDF troubleshooting.

Regards,
Srihariharan G.