### PR TITLE
913283-Resolved Syntax Error in Presentation Blazor sample

### DIFF
--- a/Document-Processing/PowerPoint/PowerPoint-Library/NET/create-read-edit-powerpoint-files-in-blazor.md
+++ b/Document-Processing/PowerPoint/PowerPoint-Library/NET/create-read-edit-powerpoint-files-in-blazor.md
@@ -94,9 +94,8 @@ Step 8: Create a new cs file with name as **PresentationService** under Data fol
 {% tabs %}
 
 {% highlight c# tabtitle="C#" %}
-@using Syncfusion.Presentation;
-@using Syncfusion.OfficeChart;
-@using System.IO;
+using Syncfusion.Presentation;
+using System.IO;
 {% endhighlight %}
 
 {% endtabs %}


### PR DESCRIPTION
 - Resolved Syntax Error in Presentation Blazor  sample.
 - Removed unwanted symbols and directives present in the code example in UG documentation
