### PR TITLE
ES-921666-Add playground button for Export HTML with body content alone sample in UG

### DIFF
--- a/Document-Processing/Word/Word-Library/NET/html.md
+++ b/Document-Processing/Word/Word-Library/NET/html.md
@@ -486,7 +486,7 @@ The following code example illustrates how to export the HTML file with only the
 
 {% tabs %}
 
-{% highlight c# tabtitle="C# [Cross-Platform]" %}
+{% highlight c# tabtitle="C# [Cross-platform]" playgroundButtonLink="https://raw.githubusercontent.com/SyncfusionExamples/DocIO-Examples/main/HTML-conversions/Export-HTML-with-body-content/.NET/Export-HTML-with-body-content/Program.cs" %}
 //Load an existing Word document.
 using (FileStream fileStreamPath = new FileStream("Input.docx", FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
 {


### PR DESCRIPTION
Added playground button for Export HTML with body content alone sample in UG.

https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/921666