### PR TITLE
201866-Site-Audit-SERPSTAT-Issue-Title-too-Long -Document processing

### DIFF
--- a/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-apply-rotation-and-transparency-to-background-image.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-apply-rotation-and-transparency-to-background-image.md
@@ -1,5 +1,5 @@
 ---
-title: How to apply rotation and transparency to background image | XlsIO | Syncfusion
+title: Set rotation and transparency to Excel sheet background | Syncfusion
 description: This page explains how to apply rotation and transparency to background image using Syncfusion .NET Excel library (XlsIO).
 platform: document-processing
 control: XlsIO

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-fix-the-argument-out-of-range-exception-when-accessing-a-large-number-of-rows-and-columns.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-fix-the-argument-out-of-range-exception-when-accessing-a-large-number-of-rows-and-columns.md
@@ -1,5 +1,5 @@
 ---
-title: Fix the ArgumentOutOfRangeException when accessing a large number of rows and columns.
+title: Avoid exceptions when accessing Excel cell ranges | Syncfusion
 description: This page helps how to fix the ArgumentOutOfRangeException when accessing a large number of rows and columns in Syncfusion .NET Excel library (XlsIO).
 platform: document-processing
 control: XlsIO

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-open-an-excel-file-with-encoding-in-net-core.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-open-an-excel-file-with-encoding-in-net-core.md
@@ -1,5 +1,5 @@
 ---
-title: How to open an Excel file with encoding in .NET Core | XlsIO | Syncfusion
+title: Open encoded Excel files in .NET | XlsIO | Syncfusion
 description: This page demonstrates with an example to open an Excel file with encoding in .NET Core using Syncfusion .NET Excel library (XlsIO).
 platform: document-processing
 control: XlsIO

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/what-is-the-behavior-of-fittopagestall-and-fittopageswide.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/what-is-the-behavior-of-fittopagestall-and-fittopageswide.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding FitToPagesTall and FitToPagesWide Settings in Excel Print Layout | Syncfusion
+title: Set page width and height in Excel using C# | XlsIO | Syncfusion
 description: This page explains the behavior of FitToPagesTall and FitToPagesWide.
 platform: document-processing
 control: XlsIO


### PR DESCRIPTION
Hi @MallikaRK 

|Title|Description|
|--|--|
|Task Category|Site Audir- SERPSTAT Issue fixes-Title too long
|Content Task Link/Mail Screenshot|![image](https://github.com/user-attachments/assets/ff6fc063-f31a-4787-adeb-f2afe9275366)![image](https://github.com/user-attachments/assets/3d5d8745-2bfe-42e8-a15a-26eb516ef8bd)|
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/document-processing-docs/pull/1095
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/201866/
|Excel/SharePoint link| NA|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B8D09F47E-B62B-44E2-8EFE-FF4F4B48899B%7D&file=Page%20with%20redirect.xlsx&nav=MTVfezAwMDAwMDAwLTAwMDEtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMH0&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&action=default&mobileredirect=true
|Changes made|Reason for changes|
|--|--|
|Title too long| According to SEO the title character counts should not be below 20 and should exceed 70
 
Regards,
Mercy A.