### PR TITLE
978970: Documentation on updating Custom AI service samples with Error handling

### DIFF
--- a/Document-Processing-toc.html
+++ b/Document-Processing-toc.html
@@ -1647,6 +1647,7 @@
 								<ul>
 									<li> <a href="/document-processing/pdf/smart-pdf-viewer/blazor/how-to/user-token-with-custom-ai-service">User Token with Custom AI service</a></li>
 									<li> <a href="/document-processing/pdf/smart-pdf-viewer/blazor/how-to/refer-SfSmartPdfViewer-script-in-application">Refer the SfSmartPdfViewer script file in application</a></li>
+									<li> <a href="/document-processing/pdf/smart-pdf-viewer/blazor/how-to/error-handling-in-custom-AI-service">Handling Error in Custom AI service</a></li>
 								</ul>
 							</li>
 							<li>

--- a/Document-Processing/PDF/Smart-PDF-Viewer/blazor/how-to/error-handling-in-custom-AI-service.md
+++ b/Document-Processing/PDF/Smart-PDF-Viewer/blazor/how-to/error-handling-in-custom-AI-service.md
@@ -1,0 +1,116 @@
+---
+layout: post
+title: Handling Error Dialogs Triggered by Custom AI Service | Syncfusion
+description: Learn how to manage error popups when integrating the Custom AI service with the Syncfusion Blazor SfSmartPdfViewer component.
+platform: document-processing
+control: SfSmartPdfViewer
+documentation: ug
+---
+
+# Handling Exceptions in Custom AI Service
+
+## Overview
+
+Since the Custom AI service operates independently from the built-in AI service, error popups must be handled at the sample level. To capture error details, use a try-catch block within the request and response logic of the Custom AI service. Once an error message is received, pass it to the Smart PDF Viewer component, where it should be displayed in a dialog—replicating the behavior of the default built-in error popup.
+
+## Capture Error in CustomService
+
+Exceptions that occur while creating a request to the custom AI service are captured using try-catch blocks. The resulting error message is assigned to the DialogMessage property, and the OnDialogOpen event is triggered to notify other components such as Home so they can display the error in a dialog appropriately.
+
+```cs
+public class GeminiService
+{
+    public event Action OnDialogOpen;
+
+    public string DialogMessage { get; private set; }
+
+    private void RaiseDialogOpen()
+    {
+        OnDialogOpen?.Invoke();
+    }
+
+    public async Task<string> CompleteAsync(IList<ChatMessage> chatMessages)
+    {
+        try
+        {
+            // Add the request logic for the Custom AI service.
+        }
+        catch (Exception ex)
+        {
+            DialogMessage = ex.Message; // Set the value
+            RaiseDialogOpen();
+            return "";
+        }
+    }
+}
+```
+
+## Configure the Dialog Service
+
+Configure the dialog service in `Program.cs` to enable error display functionality when a request or response to the Custom AI service fails. This setup ensures that any errors encountered during communication with the service can be shown in a dialog component.
+
+```cs
+
+builder.Services.AddScoped<SfDialogService>();
+
+```
+
+## Show the Error Dialog
+
+In the Smart PDF Viewer, error messages are displayed using SfDialogService. The component listens for the OnDialogOpen event from CustomService, and when triggered, the OpenDialog method calculates the dialog size dynamically based on the length of the error message and presents it accordingly. To ensure efficient resource management, the event subscription is properly disposed of when the component is no longer in use.
+
+```C#
+
+public partial class Home : IDisposable
+{
+    [Inject]
+    public GeminiService? GeminiService { get; set; }
+
+    [Inject]
+    public SfDialogService? DialogService { get; set; }
+
+    private string? DialogText { get; set; }
+
+    public async void OpenDialog()
+    {
+        DialogText = GeminiService!.DialogMessage;
+
+        int fontSize = 16;
+        int charWidth = (int)(fontSize * 0.6);
+        int baseWidth = 48;
+        int baseHeight = 176;
+
+        int textLength = DialogText?.Length ?? 0;
+        int calculatedWidth = (textLength * charWidth) + baseWidth;
+        int calculatedHeight = fontSize * 2 + baseHeight;
+
+        int minWidth = 400;
+        int maxWidth = 600;
+        int minHeight = 280;
+        int maxHeight = 600;
+
+        string width = $"{Math.Clamp(calculatedWidth, minWidth, maxWidth)}px";
+        string height = $"{Math.Clamp(calculatedHeight, minHeight, maxHeight)}px";
+
+        await DialogService!.AlertAsync(DialogText, "Custom service exception", new DialogOptions()
+        {
+            ShowCloseIcon = true,
+            Width = width,
+            Height = height
+        });
+    }
+
+    protected override void OnInitialized()
+    {
+        GeminiService!.OnDialogOpen += OpenDialog;
+    }
+
+    public void Dispose()
+    {
+        GeminiService!.OnDialogOpen -= OpenDialog;
+    }
+}
+
+```
+
+[View sample in GitHub](https://github.com/SyncfusionExamples/blazor-smart-pdf-viewer-examples/tree/master/Custom%20Services/GeminiService)


### PR DESCRIPTION
### Description

Handled the error received on the request and response on the Custom AI service of the Smart PDF Viewer and shown the error message in the dialog has same has the build-in AI service error popup.