### PR TITLE
207648-Site-Audit-SERPTAT-Help-Domain-Title-too-long-Excel-library-

### DIFF
--- a/Document-Processing/Excel/Excel-Library/NET/faqs/does-xlsio-support-editing-an-Excel-document-that-is-already-open-in-Microsoft-Excel.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/does-xlsio-support-editing-an-Excel-document-that-is-already-open-in-Microsoft-Excel.md
@@ -1,5 +1,5 @@
 ---
-title: Does XlsIO support editing an Excel document that is already open in Microsoft Excel? | XlsIO | Syncfusion
+title: Does XlsIO allow editing an open Excel file? | Syncfusion
 description: This page explains whether the Syncfusion .NET Excel library (XlsIO) supports editing an Excel document that is already open in Microsoft Excel.
 platform: document-processing
 control: XlsIO

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/what-is-the-behavior-of-fittopagestall-and-fittopageswide.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/what-is-the-behavior-of-fittopagestall-and-fittopageswide.md
@@ -1,6 +1,6 @@
 ---
-title: Understanding FitToPagesTall and FitToPagesWide Settings in Excel Print Layout | Syncfusion
-description: This page explains the behavior of FitToPagesTall and FitToPagesWide.
+title: Fit-to-Page Settings in Print Layouts | XlsIO | Syncfusion®
+description: This page explains the behavior of the FitToPagesTall and FitToPagesWide settings in print layouts when using the .NET Excel Library (XlsIO).
 platform: document-processing
 control: XlsIO
 documentation: UG


### PR DESCRIPTION
Hi @YvoneAtienoOnyango 

|Title|Description|
|--|--|
|Task Category|Site Audit- SERPSTAT EJ2 Issue Fixes-Title too Long and description too short
|Content Task Link/Mail Screenshot|https://syncfusion-content.bolddesk.com/support/tickets/4800 / https://syncfusion-content.bolddesk.com/support/tickets/4885
|UX task|NA
|Hotfix|https://github.com/syncfusion-content/document-processing-docs/pull/1289
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/207648
|Excel/SharePoint link| 

|Changes made|Reason for changes|
|--|--|
|Title too Long|According to SEO title should have character counts between 20-70 counts|
|Description too short|According to SEO description should have character counts between 100-160 counts|
 

Regards,
Mercy A.
