### PR TITLE
981582: Restructure the documentation content second set of How to section in PDF viewer

### DIFF
--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/check-status-of-annotations-or-comments.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotations or comments in Blazor SfPdfViewer | Syncfusion
-description: Learn how to retrieve the review status (State and StateModel) of annotations or comments using the Review property and GetAnnotationsAsync in the Syncfusion Blazor SfPdfViewer component.
+title: Check the status of the comments in Blazor SfPdfViewer | Syncfusion
+description: Learn how to retrieve the review status of comments using the Review property and GetAnnotationsAsync in the Syncfusion Blazor SfPdfViewer component.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/check-status-of-annotations-or-comments.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotations in Blazor SfPdfViewer | Syncfusion
-description: Learn here all about how to check the status of annotations or comments in Syncfusion Blazor SfPdfViewer component and more.
+title: Check the status of annotations or comments in Blazor SfPdfViewer | Syncfusion
+description: Learn how to retrieve the review status (State and StateModel) of annotations or comments using the Review property and GetAnnotationsAsync in the Syncfusion Blazor SfPdfViewer component.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug
@@ -9,9 +9,9 @@ documentation: ug
 
 # Check the status of annotations or comments in Blazor SfPdfViewer
 
-The Syncfusion&reg; Blazor SfPdfViewer component allows to check the status of the annotations in the SfPdfViewer using the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfAnnotation.html) class.
+The Syncfusion Blazor SfPdfViewer component supports retrieving the review status of annotations and comments through the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfAnnotation.html) class. This enables identifying the State (for example, Accepted, Rejected) and the StateModel (for example, Review, Comment) associated with each annotation.
 
-The following code example shows the review status of the annotation.
+The following code example shows how to obtain the review status of each annotation and log it to the browser console.
 
 ```cshtml
 @using Syncfusion.Blazor.SfPdfViewer

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: View the created PDF document | Syncfusion
-description: Learn here all about View the created PDF document in Syncfusion Blazor SfPdfviewer component and more.
+description: Learn how to display a runtime-generated PDF in the Syncfusion Blazor SfPdfViewer using the Created event.
 platform: document-processing
-control: SfPdfviewer
+control: SfPdfViewer
 documentation: ug
 ---
 
 # View the created PDF document
 
-The Syncfusion&reg; Blazor SfPdfViewer component allows you to view the created PDF document using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerEvents_Created) event.
+Use the Syncfusion&reg; Blazor PDF Viewer to display a PDF that is generated at runtime when the viewer initializes using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerEvents_Created) event. The sample below targets the SfPdfViewer component and binds the generated document to the [**DocumentPath**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.SfPdfViewer2.html#Syncfusion_Blazor_SfPdfViewer_SfPdfViewer2_DocumentPath) property via a data URI.
 
-The following code example shows how to view the created PDF document.
+The following example demonstrates generating a PDF in memory and rendering it as soon as the viewer is created.
 
 ```cshtml
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
@@ -7,7 +7,7 @@ control: SfPdfViewer
 documentation: ug
 ---
 
-# View the created PDF document
+# Preview the newly created PDF file
 
 Use the Syncfusion&reg; Blazor PDF Viewer to display a PDF that is generated at runtime when the viewer initializes using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerEvents_Created) event. The sample below targets the SfPdfViewer component and binds the generated document to the [**DocumentPath**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.SfPdfViewer2.html#Syncfusion_Blazor_SfPdfViewer_SfPdfViewer2_DocumentPath) property via a data URI.
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/create-sfpdfviewer.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: View the created PDF document | Syncfusion
+title: Preview the Generated PDF Document | Syncfusion
 description: Learn how to display a runtime-generated PDF in the Syncfusion Blazor SfPdfViewer using the Created event.
 platform: document-processing
 control: SfPdfViewer

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/customize-arrow-annotation-heads.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/customize-arrow-annotation-heads.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in Blazor SfPdfViewer | Syncfusion
+title: Customize the arrow annotation head in Blazor SfPdfViewer | Syncfusion
 description: Learn how to customize or remove the start and end arrow heads in the Syncfusion Blazor SfPdfViewer using ArrowSettings and LineHeadStyle.
 platform: document-processing
 control: SfPdfViewer

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/customize-arrow-annotation-heads.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/customize-arrow-annotation-heads.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in SfPdfviewer | Syncfusion
-description: Learn here all about how to increase the connection buffer size in Syncfusion Blazor SfPdfviewer component and more.
+title: Customize the arrow annotation heads in Blazor SfPdfViewer | Syncfusion
+description: Learn how to customize or remove the start and end arrow heads in the Syncfusion Blazor SfPdfViewer using ArrowSettings and LineHeadStyle.
 platform: document-processing
-control: SfPdfviewer
+control: SfPdfViewer
 documentation: ug
 ---
 
 # Customize the arrow annotation heads in Blazor SfPdfViewer Component
 
-You can customize the arrow annotation using the ArrowSettings API.
+Use the [ArrowSettings](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerArrowSettings.html) API to customize arrow annotations, including the start and end arrow head styles.
 
-The following code illustrates how to remove the starting arrow and end arrow from arrow annotation.
+The following example shows how to remove the start and end arrow heads for arrow annotations.
 
 ```cshtml
 @using Syncfusion.Blazor.SfPdfviewer
@@ -46,6 +46,8 @@ The following code illustrates how to remove the starting arrow and end arrow fr
     }
 }
 ```
+
+N> ArrowSettings controls the default arrow head styles for annotations created using the toolbar or programmatically. Set LineHeadStartStyle and LineHeadEndStyle to LineHeadStyle.None to remove heads. Other common values include LineHeadStyle.Closed, LineHeadStyle.Round, LineHeadStyle.Square, LineHeadStyle.ClosedArrow, LineHeadStyle.Diamond and LineHeadStyle.Open.
 
 [View sample in GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Annotations/Shapes/Remove%20arrow%20annotation%20heads).
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Move the scrollbar to the exact location of annotations | Syncfusion
-description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion Blazor SfPdfViewer component and more.
+description: Learn how to scroll to the location of annotations in the Syncfusion Blazor SfPdfViewer component.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug
@@ -9,9 +9,9 @@ documentation: ug
 
 # Move the scrollbar to the exact location of annotations
 
-The Syncfusion&reg; Blazor SfPdfViewer component allows you to move the scrollbar to the exact location of annotations present in a loaded PDF document using the [GoToBookmarkAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_GoToBookmarkAsync_System_Int32_System_Double_) method.
+Use the Syncfusion&reg; Blazor SfPdfViewer component to scroll to the location of an annotation in a loaded PDF by calling the [GoToBookmarkAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_GoToBookmarkAsync_System_Int32_System_Double_) method with the target page number and vertical offset (from the top of the page).
 
-The following code example shows how to move the scrollbar to annotation location.
+The following example shows how to scroll to an annotation.
 
 ```cshtml
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Move the scrollbar to the exact location of annotations | Syncfusion
+title: Move the scrollbar to the exact annotations location | Syncfusion
 description: Learn how to scroll the scrollbar precisely to the location of annotations in the Syncfusion Blazor SfPdfViewer component.
 platform: document-processing
 control: SfPdfViewer

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/move-scrollbar.md
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: Move the scrollbar to the exact location of annotations | Syncfusion
-description: Learn how to scroll to the location of annotations in the Syncfusion Blazor SfPdfViewer component.
+description: Learn how to scroll the scrollbar precisely to the location of annotations in the Syncfusion Blazor SfPdfViewer component.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug
 ---
 
-# Move the scrollbar to the exact location of annotations
+# Scroll to the Exact Annotation position Using Scrollbar
 
 Use the Syncfusion&reg; Blazor SfPdfViewer component to scroll to the location of an annotation in a loaded PDF by calling the [GoToBookmarkAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_GoToBookmarkAsync_System_Int32_System_Double_) method with the target page number and vertical offset (from the top of the page).
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/show-or-hide-sfpdfviewer-dynamically.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/show-or-hide-sfpdfviewer-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion
-description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion Blazor SfPdfViewer component and more.
+title: Show or hide the Blazor SfPdfViewer dynamically in Blazor | Syncfusion
+description: Learn how to dynamically show or hide the Syncfusion Blazor SfPdfViewer, toggle visibility with a button, and load PDFs from a local file.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Show or hide the SfPdfViewer Component dynamically in Blazor 
 
-In the below code, the SfPdfViewer is hidden at page load. Then, on clicking a button, the SfPdfViewer container will be loaded. When the user clicks on a PDF file (here it is demonstrated with buttons), the SfPdfViewer already present on the same page will be updated to show the selected document. 
+The following example initializes the PDF Viewer hidden and toggles its visibility with a button. When shown, selecting a source loads a PDF either from a physical path or a remote URL into the same viewer instance using a Base64 data URI. Ensure the container has an explicit size so Height="100%" and Width="100%" render correctly.
 
 ```cshtml
 
@@ -70,7 +70,7 @@ In the below code, the SfPdfViewer is hidden at page load. Then, on clicking a b
 }
 ```
 
-[View sample in GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Common/Render%20the%20PDF%20Viewer%20on%20a%20button%20click).
+[View the Blazor SfPdfViewer toggle sample on GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Common/Render%20the%20PDF%20Viewer%20on%20a%20button%20click).
 
 ## See also
 

--- a/Document-Processing/PDF/PDF-Viewer/blazor/how-to/suppress-error-message.md
+++ b/Document-Processing/PDF/PDF-Viewer/blazor/how-to/suppress-error-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Suppress the error dialog in the Blazor SfPdfViewer | Syncfusion
-description: Learn here all about how to suppress the error dialog in Syncfusion Blazor SfPdfViewer component and more.
+description: Learn how to suppress the built-in error dialog in the Syncfusion Blazor SfPdfViewer component using the EnableErrorDialog property.
 platform: document-processing
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Suppress the error dialog in Blazor SfPdfViewer Component
 
-The Syncfusion&reg; Blazor SfPdfViewer component allows you to suppress or disable the error dialog box displayed in the SfPdfViewer using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_EnableErrorDialog) property. The default value of the property is `true`.
+The Syncfusion&reg; Blazor SfPdfViewer component supports suppressing the built-in error dialog using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_EnableErrorDialog) property. When EnableErrorDialog is set to false, the error dialog is not displayed. The default value is true. Applications can handle errors through custom logic when the dialog is disabled.
 
 The following code example shows how to suppress the error dialog.
 
@@ -29,4 +29,4 @@ The following code example shows how to suppress the error dialog.
 }
 ```
  
-[View sample in GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Common/Supress%20the%20Error%20Dialog)
+[View sample on GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Common/Supress%20the%20Error%20Dialog)


### PR DESCRIPTION
### Description
Re-structing the documentation content second set of the How to section of PDF Viewer. On behalf of the internal team improvements.

### Image Changes
Nil.