### PR TITLE
986879-UG for how to avoid a ParseException when modifying formulas with undefined named ranges in a workbook

### DIFF
--- a/Document-Processing-toc.html
+++ b/Document-Processing-toc.html
@@ -5611,7 +5611,7 @@
 										<a href="/document-processing/excel/excel-library/net/faqs/does-xlsio-support-internal-links-when-converting-Excel-to-PDF">Does XlsIO support internal links when converting Excel to PDF?</a>
 									</li>
 									<li>
-										<a href="/document-processing/excel/excel-library/net/faqs/how-to-avoid-a-parse-exception-when-modifying-formulas-with-undefined-named ranges-in-a-workbook">How to avoid a ParseException when modifying formulas with undefined named ranges in a workbook?</a>
+										<a href="/document-processing/excel/excel-library/net/faqs/how-to-prevent-a-parse-exception-when-modifying-formulas-with-undefined-named-ranges-in-a-workbook">How to prevent a ParseException when modifying formulas with undefined named ranges in a workbook?</a>
 									</li>
 								</ul>
 							</li>

--- a/Document-Processing-toc.html
+++ b/Document-Processing-toc.html
@@ -5610,6 +5610,9 @@
 									<li>
 										<a href="/document-processing/excel/excel-library/net/faqs/does-xlsio-support-internal-links-when-converting-Excel-to-PDF">Does XlsIO support internal links when converting Excel to PDF?</a>
 									</li>
+									<li>
+										<a href="/document-processing/excel/excel-library/net/faqs/how-to-avoid-a-parse-exception-when-modifying-formulas-with-undefined-named ranges-in-a-workbook">How to avoid a ParseException when modifying formulas with undefined named ranges in a workbook?</a>
+									</li>
 								</ul>
 							</li>
 						</ul>

--- a/Document-Processing-toc.html
+++ b/Document-Processing-toc.html
@@ -5613,6 +5613,12 @@
 									<li>
 										<a href="/document-processing/excel/excel-library/net/faqs/how-to-prevent-a-parse-exception-when-modifying-formulas-with-undefined-named-ranges-in-a-workbook">How to prevent a ParseException when modifying formulas with undefined named ranges in a workbook?</a>
 									</li>
+									<li>
+										<a href="/document-processing/excel/excel-library/net/faqs/what-is-the-maximum-number-of-hyperlinks-allowed-in-an-Excel-worksheet">What is the maximum number of hyperlinks allowed in an Excel worksheet?</a>
+									</li> 
+									<li>
+										<a href="/document-processing/excel/excel-library/net/faqs/what-is-the-maximum-number-of-characters-allowed-in-a-single-Excel-cell">What is the maximum number of characters allowed in a single Excel cell?</a>
+									</li>
 								</ul>
 							</li>
 						</ul>

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-avoid-a-parse-exception-when-modifying-formulas-with-undefined-named ranges-in-a-workbook.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-avoid-a-parse-exception-when-modifying-formulas-with-undefined-named ranges-in-a-workbook.md
@@ -1,0 +1,18 @@
+---
+title: Avoid ParseException when modifying formulas with undefined named ranges | Syncfusion
+description: This page explains how to avoid ParseException when modifying formulas with undefined named ranges in Syncfusion .NET Excel library (XlsIO).
+platform: document-processing
+control: XlsIO
+documentation: UG
+---
+
+# How to avoid a ParseException when modifying formulas with undefined named ranges in a workbook?
+
+To prevent a ParseException when modifying formulas that reference undefined named ranges, set the following property before updating the formula:
+
+**C# Code:**
+~~~
+workbook.ThrowOnUnknownNames = false;
+~~~
+
+This ensures that formulas with undefined named ranges won't trigger errors during assignment or modification.

--- a/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-prevent-a-parse-exception-when-modifying-formulas-with-undefined-named-ranges-in-a-workbook.md
+++ b/Document-Processing/Excel/Excel-Library/NET/faqs/how-to-prevent-a-parse-exception-when-modifying-formulas-with-undefined-named-ranges-in-a-workbook.md
@@ -1,12 +1,12 @@
 ---
-title: Avoid ParseException when modifying formulas with undefined named ranges | Syncfusion
-description: This page explains how to avoid ParseException when modifying formulas with undefined named ranges in Syncfusion .NET Excel library (XlsIO).
+title: Prevent ParseException when updating formulas | Syncfusion
+description: This page explains how to prevent ParseException when modifying formulas with undefined named ranges in Syncfusion .NET Excel library (XlsIO).
 platform: document-processing
 control: XlsIO
 documentation: UG
 ---
 
-# How to avoid a ParseException when modifying formulas with undefined named ranges in a workbook?
+# Prevent ParseException from undefined named ranges
 
 To prevent a ParseException when modifying formulas that reference undefined named ranges, set the following property before updating the formula:
 


### PR DESCRIPTION
Hi @Mohan2401 sir,

Kindly review and merge the PR.