### PR TITLE
1007601: updated the getting stated folder structure app.component issue

### DIFF
--- a/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
+++ b/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
@@ -156,7 +156,7 @@ ng serve
 The following example shows a basic Spreadsheet component
 
 {% tabs %}
-{% highlight ts tabtitle="app.component.ts" %}
+{% highlight ts tabtitle="app.ts" %}
 {% include code-snippet/spreadsheet/angular/spreadsheet-cs1/src/app.ts %}
 {% endhighlight %}
 

--- a/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
+++ b/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
@@ -127,7 +127,7 @@ This can be referenced in `[src/styles.css]` using following code.
 
 ## Add Spreadsheet component
 
-Modify the template in [src/app/app.component.ts] file to render the spreadsheet component. Add the Angular Spreadsheet by using `<ejs-spreadsheet>` selector in template section of the `app.ts` file.
+Modify the template in [src/app/app.ts] file to render the spreadsheet component. Add the Angular Spreadsheet by using `<ejs-spreadsheet>` selector in template section of the `app.ts` file.
 
 ```typescript
 import { Component } from '@angular/core';

--- a/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
+++ b/Document-Processing/Excel/Spreadsheet/Angular/getting-started.md
@@ -127,7 +127,7 @@ This can be referenced in `[src/styles.css]` using following code.
 
 ## Add Spreadsheet component
 
-Modify the template in [src/app/app.component.ts] file to render the spreadsheet component. Add the Angular Spreadsheet by using `<ejs-spreadsheet>` selector in template section of the `app.component.ts` file.
+Modify the template in [src/app/app.component.ts] file to render the spreadsheet component. Add the Angular Spreadsheet by using `<ejs-spreadsheet>` selector in template section of the `app.ts` file.
 
 ```typescript
 import { Component } from '@angular/core';
@@ -141,7 +141,7 @@ import { SpreadsheetAllModule } from '@syncfusion/ej2-angular-spreadsheet'
   // specifies the template string for the Spreadsheet component
   template: `<ejs-spreadsheet> </ejs-spreadsheet>`
 })
-export class AppComponent { }
+export class App { }
 
 ```
 
@@ -157,7 +157,7 @@ The following example shows a basic Spreadsheet component
 
 {% tabs %}
 {% highlight ts tabtitle="app.component.ts" %}
-{% include code-snippet/spreadsheet/angular/spreadsheet-cs1/src/app.component.ts %}
+{% include code-snippet/spreadsheet/angular/spreadsheet-cs1/src/app.ts %}
 {% endhighlight %}
 
 {% highlight ts tabtitle="main.ts" %}

--- a/Document-Processing/code-snippet/spreadsheet/angular/spreadsheet-cs1/src/app.ts
+++ b/Document-Processing/code-snippet/spreadsheet/angular/spreadsheet-cs1/src/app.ts
@@ -12,6 +12,6 @@ standalone: true,
     selector: 'app-root',
     template: '<ejs-spreadsheet > </ejs-spreadsheet>'
 })
-export class AppComponent { }
+export class App { }
 
 

--- a/Document-Processing/code-snippet/spreadsheet/angular/spreadsheet-cs1/src/main.ts
+++ b/Document-Processing/code-snippet/spreadsheet/angular/spreadsheet-cs1/src/main.ts
@@ -1,4 +1,4 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { AppComponent } from './app.component';
+import { App } from './app/app';
 import 'zone.js';
-bootstrapApplication(AppComponent).catch((err) => console.error(err));
+bootstrapApplication(App).catch((err) => console.error(err));


### PR DESCRIPTION
Updated the getting started of Angular Spreadsheet and renamed file structure

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Angular Version | Default Root File
-- | --
Angular 2 –   Angular 19 | app.component.ts
Angular 20+ | app.ts



</div>

<!--EndFragment-->
</body>

</html>
