### PR TITLE
Resolved UG compilation failures for React optimize-sfdt

### DIFF
--- a/Document-Processing/Word/Word-Processor/react/how-to/optimize-sfdt.md
+++ b/Document-Processing/Word/Word-Processor/react/how-to/optimize-sfdt.md
@@ -27,7 +27,7 @@ As a backward compatibility to create older format SFDT files, refer to the foll
 <td>Client-side</td>
 <td>
 {% tabs %} 
-{% highlight tsx tabtitle="Component Declaration" %}
+{% highlight ts tabtitle="Component Declaration" %}
 <DocumentEditorContainerComponent></DocumentEditorContainerComponent>
 {% endhighlight %}
 {% endtabs %}


### PR DESCRIPTION
## Issue 
ClassNotFound: no lexer for alias 'tsx' found in document-processing/Word/Word-Processor/react/how-to/optimize-sfdt.md

## Solution 
tsx is used insted of ts