### PR TITLE
Task(1044664): Addressing ASP.NET Core how to section ug documentation issues

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
@@ -7,7 +7,7 @@ control: Insert Text Or Image In Table
 documentation: ug
 ---
 
-# How to insert text or image in a table in DOCX Editor
+# How to insert text or image in a table in Document Editor component
 
 Using the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) APIs, you can insert [`text`] or [`image`] in a [`table`] programmatically based on your requirement.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Insert text or image in a table in DOCX Editor | Syncfusion
-description: Learn how to insert text or an image in a table programmatically in the Syncfusion DOCX Editor component.
+description: Learn how to insert text or an image in a table programmatically in the Syncfusion Document Editor component.
 platform: document-processing
 control: Insert Text Or Image In Table
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
@@ -1,19 +1,19 @@
 ---
 layout: post
-title: How to insert text or image in table programmatically in Document Editor Component
-description: Learn how to insert text or image in table programmatically in Document Editor Component
+title: Insert text or image in a table in DOCX Editor | Syncfusion
+description: Learn how to insert text or an image in a table programmatically in the Syncfusion DOCX Editor component.
 platform: document-processing
 control: Insert Text Or Image In Table
 documentation: ug
 ---
 
-# How to insert text or image in table programmatically in  Document Editor component
+# How to insert text or image in a table in DOCX Editor
 
-Using [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) API's, you can insert [`text`] or [`image`] in [`table`] programmatically based on your requirement.
+Using the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) APIs, you can insert [`text`] or [`image`] in a [`table`] programmatically based on your requirement.
 
-Use [`selection`] API's to navigate between rows and cells.
+Use the [`selection`] APIs to navigate between rows and cells.
 
-The following example illustrates how to create 2*2 table and then add text and image programmatically.
+The following example illustrates how to create a 2x2 table and then add text and an image programmatically.
 
 
 {% tabs %}
@@ -24,5 +24,6 @@ The following example illustrates how to create 2*2 table and then add text and 
 {% endhighlight %}{% endtabs %}
 
 
-The output will be like below.
+The output will be as shown below.
+
 ![Insert text or image in table programmatically](../images/table-image.png)

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-or-image-in-table-programmatically.md
@@ -21,7 +21,8 @@ The following example illustrates how to create a 2x2 table and then add text an
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/insert-text-image-table/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Insert-text-image-table" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 The output will be as shown below.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
@@ -7,7 +7,7 @@ control: Move The Selection To Specific Position
 documentation: ug
 ---
 
-# How to move the selection to a specific position in the DOCX Editor
+# How to move selection to a specific position in the Document Editor
 
 Using the [`select`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection#select) API in the selection module, you can set the cursor position anywhere in the document.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
@@ -1,44 +1,46 @@
 ---
 layout: post
-title: Move the selection to specific position in Document Editor Component
-description: Learn how to move the selection to specific position in Document from the Document Editor Component
+title: Move selection to a specific position in DOCX Editor | Syncfusion
+description: Learn how to move the selection to a specific position in a document using the Syncfusion DOCX Editor component.
 platform: document-processing
 control: Move The Selection To Specific Position
 documentation: ug
 ---
 
-# How to move the selection to specific position in Document Editor component
+# How to move the selection to a specific position in the DOCX Editor
 
-Using [`select`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#select) API in selection module, You can set cursor position to anywhere in the document.
+Using the [`select`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#select) API in the selection module, you can set the cursor position anywhere in the document.
 
-## Selects content based on start and end hierarchical index
+N> Before using the `select` API, the DOCX Editor component must be initialized and a `DocumentEditorContainer` instance must be available. Refer to the [getting started](https://ej2.syncfusion.com/aspnet-core/documentation/document-editor/getting-started/) documentation for setup details. All hierarchical indices used by the `select` API are **zero-based**.
 
-Hierarchical index will be in below format.
+## Select content based on the start and end hierarchical index
+
+The hierarchical index follows the format shown below.
 
 `sectionIndex;blockIndex;offset`
 
-The following code snippet illustrate how to select using hierarchical index.
+The following table illustrates the hierarchical index format in detail.
+
+| Element | Hierarchical Format | Explanation |
+|---|---|---|
+| Move selection to Paragraph | `sectionIndex;blockIndex;offset` <br>**Ex:** `0;0;0` | It moves the cursor to the start of the paragraph. |
+| Move selection to Table | `sectionIndex;tableIndex;rowIndex;cellIndex;blockIndex;offset` <br>**Ex:** `0;0;0;0;1;0` | It moves the cursor to the second paragraph (zero-based block index `1`) which is inside the first row and cell of the table. |
+| Move selection to Header | `pageIndex;H;sectionIndex;blockIndex;offset` <br>**Ex:** `1;H;0;0;0` | It moves the cursor to the header on the second page. |
+| Move selection to Footer | `pageIndex;F;sectionIndex;blockIndex;offset` <br>**Ex:** `1;F;0;0;0` | It moves the cursor to the footer on the second page. |
+
+The following code snippet illustrates how to select content using the hierarchical index.
 
 ```typescript
-// Selection will occur between provided start and end offset
+// Ensure the DocumentEditorContainer is loaded before calling the APIs below.
+// Selection occurs between the provided start and end offsets.
 this.documentEdContainerIns.documentEditor.editor.insertText("Welcome");
-// The below code will select the letters “We” from inserted text “Welcome”
+// The following code selects the letters "We" from the inserted text "Welcome".
 this.documentEdContainerIns.documentEditor.selection.select("0;0;0", "0;0;2");
 ```
 
-The following table illustrates about Hierarchical index in detail.
-
-| Element |Hierarchical Format | Explanation |
-|-----------------|-------------|----|
-|Move selection to Paragraph |sectionIndex;blockIndex;offset <br>**Ex:** 0;0;0|It moves the cursor to the start of paragraph.|
-|Move selection to Table|sectionIndex;tableIndex;rowIndex;cellIndex;blockIndex;offset <br>**Ex:** 0;0;0;0;1;0|It moves the cursor to the second paragraph which is inside first row and cell of table.|
-|Move selection to header|pageIndex;H;sectionIndex;blockIndex;offset<br>**Ex:** 1;H;0;0;0|It moves cursor to the header in second page.|
-|Move selection to Footer|pageIndex;F;sectionIndex;blockIndex;offset<br>**Ex:** 1;F;0;0;0|It moves cursor to the footer in second page.|
-
 ## Get the selection start and end hierarchical index
 
-Using [`startOffset`], you can get start hierarchical index which denotes the start index of current selection.
-Similarly, using [`endOffset`], you can get end hierarchical index which denotes the end index of current selection.
+Using [`startOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#startoffset), you can get the start hierarchical index which denotes the start index of the current selection. Similarly, using [`endOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#endoffset), you can get the end hierarchical index which denotes the end index of the current selection.
 
 The following code snippet illustrate how to get the selection start and end offset on selection changes in document.
 
@@ -53,12 +55,18 @@ The following code snippet illustrate how to get the selection start and end off
 
 ## Selects the content based on left and top position
 
-Here, you can specify the [`selection settings`] to select the content based on left and top position.
+Here, you can specify the [`selection settings`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selectionSettings/) to select the content based on the left and top positions.
 
-x denotes the left position and y denotes the top position and extend denotes whether to extend or update selection.
+The available parameters are listed below.
 
-Check below code sample for reference.
+| Parameter | Description |
+|---|---|
+| `x` | The left position. The value is measured in **pixels** from the left edge of the editor area. |
+| `y` | The top position. The value is measured in **pixels** from the top edge of the editor area. |
+| `extend` | A boolean value that determines whether to extend or update the selection. When `true`, the current selection is extended from the existing start point to the specified position. When `false`, the selection is reset to the specified position. |
+
+The following code sample shows how to select content based on the left and top position.
 
 ```typescript
-this.container.documentEditor.selection.select({ x: 188.4814208984375 , y: 662.00005, extend: true });
+this.documentEdContainerIns.documentEditor.selection.select({ x: 188.4814208984375 , y: 662.00005, extend: true });
 ```

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
@@ -9,9 +9,9 @@ documentation: ug
 
 # How to move the selection to a specific position in the DOCX Editor
 
-Using the [`select`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#select) API in the selection module, you can set the cursor position anywhere in the document.
+Using the [`select`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection#select) API in the selection module, you can set the cursor position anywhere in the document.
 
-N> Before using the `select` API, the DOCX Editor component must be initialized and a `DocumentEditorContainer` instance must be available. Refer to the [getting started](https://ej2.syncfusion.com/aspnet-core/documentation/document-editor/getting-started/) documentation for setup details. All hierarchical indices used by the `select` API are **zero-based**.
+N> Before using the `select` API, the DOCX Editor component must be initialized and a `DocumentEditorContainer` instance must be available. Refer to the [getting started](https://help.syncfusion.com/document-processing/word/word-processor/asp-net-core/getting-started-core) documentation for setup details. All hierarchical indices used by the `select` API are **zero-based**.
 
 ## Select content based on the start and end hierarchical index
 
@@ -40,7 +40,7 @@ this.documentEdContainerIns.documentEditor.selection.select("0;0;0", "0;0;2");
 
 ## Get the selection start and end hierarchical index
 
-Using [`startOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#startoffset), you can get the start hierarchical index which denotes the start index of the current selection. Similarly, using [`endOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection/#endoffset), you can get the end hierarchical index which denotes the end index of the current selection.
+Using [`startOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection#get-startoffset-string), you can get the start hierarchical index which denotes the start index of the current selection. Similarly, using [`endOffset`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selection#get-endoffset-string), you can get the end hierarchical index which denotes the end index of the current selection.
 
 The following code snippet illustrate how to get the selection start and end offset on selection changes in document.
 
@@ -50,12 +50,13 @@ The following code snippet illustrate how to get the selection start and end off
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/select/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="select.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Selects the content based on left and top position
 
-Here, you can specify the [`selection settings`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selectionSettings/) to select the content based on the left and top positions.
+Here, you can specify the [`selection settings`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/selectionSettings) to select the content based on the left and top positions.
 
 The available parameters are listed below.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/move-selection-to-specific-position.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Move selection to a specific position in DOCX Editor | Syncfusion
-description: Learn how to move the selection to a specific position in a document using the Syncfusion DOCX Editor component.
+description: Learn how to move the selection to a specific position in a document using the Syncfusion Document Editor component.
 platform: document-processing
 control: Move The Selection To Specific Position
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Open Default Document in Document Editor Component
-description: Learn here all about how to open default document in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Open Default Document in DOCX Editor | Syncfusion
+description: Learn here all about how to open a default document in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Open Default Document
 documentation: ug
 ---
 
 
-# How to open a default document in DocumentEditor when initialized
+# How to open a default document in the DOCX Editor when initialized
 
-This article explains how to open a default document when DocumentEditor & DocumentEditorContainer is initialized.
+This section explains how to open a default document when the Document Editor and Document Editor Container are initialized.
 
-## Opening a default document in DocumentEditor
+## Opening a default document in the Document Editor
 
-Using `open` method in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) allows to open the Document in sfdt format. To open the document by default, call the open method in the `created` event of Document editor which gets triggered once the control is created.
+Using the `open` method in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) allows you to open the document in SFDT format. To open the document by default, call the `open` method in the `created` event of the Document Editor, which is triggered once the control is created.
 
 
 {% tabs %}
@@ -28,9 +28,9 @@ Using `open` method in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/doc
 
 
 
-## Opening a default document in DocumentEditorContainer
+## Opening a default document in the Document Editor Container
 
-To open the document by default, call the open method in the `created` event of Document editor container which gets triggered once the control is created.
+To open the document by default, call the `open` method in the `created` event of the Document Editor Container, which is triggered once the control is created.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Default Document in DOCX Editor | Syncfusion
-description: Learn here all about how to open a default document in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about how to open a default document in the Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Open Default Document
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to open a default document in the DOCX Editor when initialized
+# How to open default document in the Document Editor when initialized
 
 This section explains how to open a default document when the Document Editor and Document Editor Container are initialized.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # Open a document from a URL
 
-## How to open a document from a URL in the DOCX Editor
+## How to open a document from a URL in the Document Editor
 
 This article explains how to open a document from a URL in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Open Document By Address in DOCX Editor | Syncfusion
-description: Learn here all about how to open a document by address in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about how to open a document by address in the Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Open Document By Address
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
@@ -1,18 +1,18 @@
 ---
 layout: post
-title: Open Document By Address in Document Editor Component
-description: Learn here all about open document by address in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Open Document By Address in DOCX Editor | Syncfusion
+description: Learn here all about how to open a document by address in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Open Document By Address
 documentation: ug
 ---
 
 
-# Open a document from URL
+# Open a document from a URL
 
-## How to open a document from URL in DocumentEditor
+## How to open a document from a URL in the DOCX Editor
 
-This article explains how to open a document from URL in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+This article explains how to open a document from a URL in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
 
 {% tabs %}
@@ -28,15 +28,15 @@ This article explains how to open a document from URL in [ASP.NET Core DOCX Edit
 import * as ReactDOM from 'react-dom';
 import * as React from 'react';
 import {
-  DocumentEditorContainerComponent,Toolbar } from '@syncfusion/ej2-react-documenteditor';
+  DocumentEditorContainerComponent, Toolbar } from '@syncfusion/ej2-react-documenteditor';
 
 DocumentEditorContainerComponent.Inject(Toolbar);
 export class App extends React.Component<{}, {}> {
   container: DocumentEditorContainerComponent;
-  public contentChanged:boolean=false;
-  onClick():void {
+  public contentChanged: boolean = false;
+  onClick(): void {
     let http: XMLHttpRequest = new XMLHttpRequest();
-    //add your url in which you want to open document inside the ""
+    // Add your URL in which you want to open the document inside the "".
     let content = { fileUrl: "" };
     let baseurl: string = "/api/documenteditor/ImportFileURL";
     http.open("POST", baseurl, true);
@@ -44,8 +44,8 @@ export class App extends React.Component<{}, {}> {
     http.onreadystatechange = () => {
         if (http.readyState === 4) {
             if (http.status === 200 || http.status === 304) {
-                //open the SFDT text in Document Editor
-                container.documentEditor.open(http.responseText);
+                // Open the SFDT text in the Document Editor.
+                this.container.documentEditor.open(http.responseText);
             }
         }
     };
@@ -65,16 +65,15 @@ export class App extends React.Component<{}, {}> {
   }
 }
 ReactDOM.render(<App />, document.getElementById('root'));
-
 ```
 
 
 ```csharp
 [AcceptVerbs("Post")]
-public string ImportFileURL([FromBody]FileUrlInfo param)
+public string ImportFileURL([FromBody] FileUrlInfo param)
 {
     try {
-        using(WebClient client = new WebClient())
+        using (WebClient client = new WebClient())
         {
             MemoryStream stream = new MemoryStream(client.DownloadData(param.fileUrl));
             WordDocument document = WordDocument.Load(stream, FormatType.Docx);

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
@@ -20,7 +20,8 @@ This article explains how to open a document from a URL in the [ASP.NET Core DOC
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/open-by-url/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Open-by-url.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
@@ -7,7 +7,7 @@ control: Optimize the SFDT file
 documentation: ug
 ---
 
-# How to optimize the SFDT file
+# How to optimize the SFDT file in ASP.NET Core DOCX Editor
 
 Starting from version v21.1.x, the SFDT file generated in the Word Processor component is optimized by default to reduce the file size. All static keys are minified, and the final JSON string is compressed. This helps reduce the SFDT file size relative to a DOCX file and provides the following benefits:
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Optimize the SFDT file in Document Editor Component
-description: Learn here all about optimize the SFDT file in Document Editor in Syncfusion Document Editor component of syncfusion and more.
+title: Optimize the SFDT file in DOCX Editor | Syncfusion
+description: Learn here all about how to optimize the SFDT file in the Syncfusion DOCX Editor component of Syncfusion and more.
 platform: document-processing
 control: Optimize the SFDT file
 documentation: ug
@@ -9,14 +9,16 @@ documentation: ug
 
 # How to optimize the SFDT file
 
-Starting from version v21.1.x, the SFDT file generated in Word Processor component is optimized by default to reduce the file size. All static keys are minified, and the final JSON string is compressed. This helps reduce the SFDT file size relative to a DOCX file and provides the following benefits,
+Starting from version v21.1.x, the SFDT file generated in the Word Processor component is optimized by default to reduce the file size. All static keys are minified, and the final JSON string is compressed. This helps reduce the SFDT file size relative to a DOCX file and provides the following benefits:
+
 * File transfer between client and server through the internet gets faster.
 * The new optimized SFDT files require less storage space than the old SFDT files.
-Hence, the optimized SFDT file can't be directly manipulated as JSON string.
 
-> This feature comes with a public API to switch between the old and new optimized SFDT format, allowing backward compatibility.
+Hence, the optimized SFDT file can't be directly manipulated as a JSON string.
 
-As a backward compatibility to create older format SFDT files, refer the following code changes,
+N> This feature comes with a public API to switch between the old and new optimized SFDT format, allowing backward compatibility.
+
+To create older-format SFDT files for backward compatibility, refer to the following code changes:
 
 <table>
 <tr>
@@ -70,7 +72,7 @@ string sfdt = Newtonsoft.Json.JsonConvert.SerializeObject(sfdtDocument);
 </tr>
 </table>
 
-To convert from older format SFDT from a new optimized SFDT file, refer the following code example,
+To convert from older-format SFDT to a new optimized SFDT file, refer to the following code example:
 
 <table>
 <tr>
@@ -95,7 +97,7 @@ To convert from older format SFDT from a new optimized SFDT file, refer the foll
 <td>
 {% tabs %}
 {% highlight C# tabtitle="C#" %}
-using(Syncfusion.DocIO.DLS.WordDocument docIODocument = WordDocument.Save(optimizedSfdt)) {
+using (Syncfusion.DocIO.DLS.WordDocument docIODocument = WordDocument.Save(optimizedSfdt)) {
     sfdtDocument = WordDocument.Load(docIODocument);
     sfdtDocument.OptimizeSfdt = false;
     string oldSfdt = JsonSerializer.Serialize(sfdtDocument);

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/optimize-sfdt.md
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: Optimize the SFDT file in DOCX Editor | Syncfusion
-description: Learn here all about how to optimize the SFDT file in the Syncfusion DOCX Editor component of Syncfusion and more.
+description: Learn here all about how to optimize the SFDT file in the Syncfusion Document Editor component of Syncfusion and more.
 platform: document-processing
 control: Optimize the SFDT file
 documentation: ug
 ---
 
-# How to optimize the SFDT file in ASP.NET Core DOCX Editor
+# How to optimize the SFDT file in ASP.NET Core Document Editor
 
 Starting from version v21.1.x, the SFDT file generated in the Word Processor component is optimized by default to reduce the file size. All static keys are minified, and the final JSON string is compressed. This helps reduce the SFDT file size relative to a DOCX file and provides the following benefits:
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Set Default Format In Document Editor in DOCX Editor | Syncfusion
-description: Learn here all about how to set default format in Document Editor in Syncfusion DOCX Editor component of Syncfusion and more.
+description: Learn here all about how to set default format in Document Editor in Syncfusion Document Editor component of Syncfusion and more.
 platform: document-processing
 control: Set Default Format In Document Editor
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Set Default Format In Document Editor in Document Editor Component
-description: Learn here all about how to set default format in Document Editor in Syncfusion Document Editor component of syncfusion and more.
+title: Set Default Format In Document Editor in DOCX Editor | Syncfusion
+description: Learn here all about how to set default format in Document Editor in Syncfusion DOCX Editor component of Syncfusion and more.
 platform: document-processing
 control: Set Default Format In Document Editor
 documentation: ug
 ---
 
 
-# How to set the default character, paragraph and section format in Document Editor component
+# How to set the default character, paragraph and section format
 
 You can set the default character format, paragraph format and section format in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
 ## Set the default character format
 
-You can use `setDefaultCharacterFormat` method to set the default character format. For example, Document editor default font size is 11 and you can change it as any valid value.
+You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the Document Editor default font size is 11 and you can change it to any valid value.
 
 
 {% tabs %}
@@ -22,7 +22,8 @@ You can use `setDefaultCharacterFormat` method to set the default character form
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/character-format-font/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Character-format-font.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 Similarly, you can change the required `CharacterFormatProperties` default value.
@@ -32,12 +33,13 @@ Similarly, you can change the required `CharacterFormatProperties` default value
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/character-format/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Character-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Set the default paragraph format
 
-You can use `setDefaultParagraphFormat` API to set the default paragraph format. You can change the required `ParagraphFormatProperties` default value.
+You can use the `setDefaultParagraphFormat` API to set the default paragraph format. You can change the required `ParagraphFormatProperties` default value.
 
 
 {% tabs %}
@@ -45,13 +47,14 @@ You can use `setDefaultParagraphFormat` API to set the default paragraph format.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/paragraph-format/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Paragraph-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 ## Set the default section format
 
-You can use `setDefaultSectionFormat` API to set the default section format. You can change the required `SectionFormatProperties` default value.
+You can use the `setDefaultSectionFormat` API to set the default section format. You can change the required `SectionFormatProperties` default value.
 
 
 {% tabs %}
@@ -59,5 +62,6 @@ You can use `setDefaultSectionFormat` API to set the default section format. You
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/section-format/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Section-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 


### PR DESCRIPTION
Addressing ASP.NET Core how to section ug documentation issues

How To ==> Insert text or image in table programmatically
<img width="876" height="281" alt="image" src="https://github.com/user-attachments/assets/7aa26875-b30d-4312-899e-788d51a82dbb" />

How To ==> Move selection to specific position
<img width="882" height="274" alt="image" src="https://github.com/user-attachments/assets/2b952db6-15ef-43c6-9c06-70a4b13f3701" />

How To ==>Open default document

<img width="710" height="278" alt="image" src="https://github.com/user-attachments/assets/84ee455c-bee8-44b5-9523-aedec629e5df" />

How To ==> Open document by address

<img width="786" height="268" alt="image" src="https://github.com/user-attachments/assets/23d0e3d6-7e74-4d7e-aaf7-ce7852c62933" />

How To => Optimized Sfdt
<img width="794" height="269" alt="image" src="https://github.com/user-attachments/assets/a1eb2952-7bd2-4dc8-92ba-5c1c37f13290" />



