### PR TITLE
Task(1044664): Addressing ASP.NET Core DOCX Editor ug page issues

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Override The Keyboard Shortcuts in DOCX Editor | Syncfusion
-description: Learn here all about how to override the keyboard shortcuts in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about how to override the keyboard shortcuts in the Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Override The Keyboard Shortcuts
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to override the keyboard shortcuts in the DOCX Editor
+# How to override the keyboard shortcuts in the Document Editor
 
 The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) triggers the [`keyDown`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_KeyDown) event every time a key is entered and provides an instance of `DocumentEditorKeyDownEventArgs`. You can use the `isHandled` property to override the keyboard shortcut behavior.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Override The Keyboard Shortcuts in Document Editor Component
-description: Learn here all about override the keyboard shortcuts in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Override The Keyboard Shortcuts in DOCX Editor | Syncfusion
+description: Learn here all about how to override the keyboard shortcuts in the Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Override The Keyboard Shortcuts
 documentation: ug
 ---
 
 
-# How to override the keyboard shortcuts in document editor
+# How to override the keyboard shortcuts in the DOCX Editor
 
-[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) triggers the [`keyDown`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_KeyDown) event every time when any key is entered and provides an instance of `DocumentEditorKeyDownEventArgs`. You can use the `isHandled` property to override the keyboard shortcut behavior.
+The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) triggers the [`keyDown`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_KeyDown) event every time a key is entered and provides an instance of `DocumentEditorKeyDownEventArgs`. You can use the `isHandled` property to override the keyboard shortcut behavior.
 
-## Preventing default keyboard shortcut
+## Preventing the default keyboard shortcut
 
-The following code shows how to prevent the `CTRL + C` keyboard shortcut for copying selected content in document editor.
+The following code shows how to prevent the `Ctrl + C` keyboard shortcut for copying selected content in the Document Editor.
 
 
 {% tabs %}
@@ -22,14 +22,15 @@ The following code shows how to prevent the `CTRL + C` keyboard shortcut for cop
 {% include code-snippet/document-editor/asp-net-core/prevent-default/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Prevent-default.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-## Override or define the keyboard shortcut
+## Override or define a keyboard shortcut
 
-Override or define a new keyboard shortcut behavior instead of preventing the keyboard shortcut.
+You can override or define a new keyboard shortcut behavior instead of preventing the keyboard shortcut.
 
-For example, `Ctrl + S` keyboard shortcut saves the document in SFDT format by default, and there is no behavior for `Ctrl + Alt + S`. The following code demonstrates how to override the `Ctrl + S` shortcut to save a document in DOCX format and define `Ctrl + Alt + S` to save the document in SFDT format.
+For example, the `Ctrl + S` keyboard shortcut saves the document in SFDT format by default, and there is no behavior for `Ctrl + Alt + S`. The following code demonstrates how to override the `Ctrl + S` shortcut to save a document in DOCX format and define `Ctrl + Alt + S` to save the document in SFDT format.
 
 
 {% tabs %}
@@ -37,5 +38,6 @@ For example, `Ctrl + S` keyboard shortcut saves the document in SFDT format by d
 {% include code-snippet/document-editor/asp-net-core/override/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Override.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -36,7 +36,8 @@ Using the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Sync
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/read-only/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Read-only.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in [`Document Editor Container`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html) and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in [`Document Editor`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html) based on your requirement to change component to read only mode.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to open a document in read only mode by default in DOCX Editor
+# How to open document in read only mode by default in Document Editor
 
 This section explains how to open a document in read only mode by default in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor and Document Editor Container).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Read By Default in Document Editor Component | Syncfusion
-description: Learn here all about read by default in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Read By Default in DOCX Editor Component | Syncfusion
+description: Learn here all about read by default in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Read By Default
 documentation: ug
 ---
 
 
-# How to open a document in read only mode by default in Document Editor
+# How to open a document in read only mode by default in DOCX Editor
 
-This article explains how to open a document in read only mode by default in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) & Document Editor Container.
+This section explains how to open a document in read only mode by default in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor and Document Editor Container).
 
 ## Opening a document in read only mode by default in Document Editor
 
-Using [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) property in Document editor allows to enable or disable read only mode in the document editor.
+Using the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) property in the Document Editor allows you to enable or disable read only mode in the document editor.
 
 
 {% tabs %}
@@ -25,9 +25,9 @@ Using [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ
 {% endhighlight %}{% endtabs %}
 
 
-## Opening a document in ready only mode by default in Document Editor Container
+## Opening a document in read only mode by default in Document Editor Container
 
-Using [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) property in Document editor container allows to enable or disable read only mode in the document editor.
+Using the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) property in the Document Editor Container allows you to enable or disable read only mode in the document editor.
 
 
 {% tabs %}
@@ -38,4 +38,4 @@ Using [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusi
 {% endhighlight %}{% endtabs %}
 
 
-N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in [`DocumentEditorContainerComponent`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html) and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in [`DocumentEditorComponent`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html) based on your requirement to change component to read only mode.
+N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in [`Document Editor Container`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html) and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in [`Document Editor`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html) based on your requirement to change component to read only mode.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -22,7 +22,8 @@ Using the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusio
 {% include code-snippet/document-editor/asp-net-core/read-only/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Read-only.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Opening a document in read only mode by default in Document Editor Container

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Read By Default in DOCX Editor Component | Syncfusion
-description: Learn here all about read by default in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about read by default in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Read By Default
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to change height and width of Document Editor component
+# How to change height and width of Document Editor
 
 This section explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Resize Document Editor in DOCX Editor Component
+title: Resize Document Editor in DOCX Editor | Syncfusion
 description: Learn here all about how to resize Document Editor in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Resize Document Editor

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Resize Document Editor in DOCX Editor | Syncfusion
-description: Learn here all about how to resize Document Editor in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about how to resize Document Editor in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Resize Document Editor
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -8,9 +8,9 @@ documentation: ug
 ---
 
 
-# How to change height and width of DOCX Editor component
+# How to change height and width of Document Editor component
 
-This section explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor).
+This section explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
 ## Change height of Document Editor
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Resize Document Editor in Document Editor Component
-description: Learn here all about how to resize Document Editor in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Resize Document Editor in DOCX Editor Component
+description: Learn here all about how to resize Document Editor in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Resize Document Editor
 documentation: ug
 ---
 
 
-# How to change height and width of Document Editor component
+# How to change height and width of DOCX Editor component
 
-This article explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+This section explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor).
 
 ## Change height of Document Editor
 
-DocumentEditorContainer initially renders with default height. You can change the height of document editor using `height` property, the value which is in pixel.
+DocumentEditorContainer initially renders with a default height. You can change the height of the Document Editor using the `height` property, the value of which is in pixels.
 
 
 {% tabs %}
@@ -22,15 +22,16 @@ DocumentEditorContainer initially renders with default height. You can change th
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/change-height/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Change-height.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
-Similarly, you can use `height` property for DocumentEditor also.
+Similarly, you can use the `height` property for DocumentEditor also.
 
 ## Change width of Document Editor
 
-DocumentEditorContainer initially renders with default width. You can change the width of document editor using `width` property, the value which is in percent.
+DocumentEditorContainer initially renders with a default width. You can change the width of the Document Editor using the `width` property, the value of which is in percent.
 
 
 
@@ -39,15 +40,16 @@ DocumentEditorContainer initially renders with default width. You can change the
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/change-width/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Change-width.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
-Similarly, you can use `width` property for DocumentEditor also.
+Similarly, you can use the `width` property for DocumentEditor also.
 
 ## Resize Document Editor
 
-Using `resize` method, you change height and width of Document editor.
+Using the `resize` method, you can change the height and width of the Document Editor.
 
 
 {% tabs %}
@@ -55,5 +57,6 @@ Using `resize` method, you change height and width of Document editor.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/resize/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Resize.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
@@ -1,19 +1,19 @@
 ---
 layout: post
-title: Retrieve the whole document and bookmark content as text in Document Editor Component
-description: Learn how to retrieve the whole document and bookmark content as text from the Syncfusion Document Editor Component
+title: Retrieve the document and bookmark content as text in DOCX Editor
+description: Learn how to retrieve the whole document and bookmark content as text from the Syncfusion DOCX Editor Component
 platform: document-processing
 control: Retrieve The Whole Document And Bookmark Content As Text
 documentation: ug
 ---
 
-# How to retrieve the whole document and bookmark content as text in  Document Editor component
+# How to retrieve the whole document and bookmark text in DOCX Editor
 
 You can get the bookmark or whole document content from the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component as plain text and SFDT (rich text).
 
 ## Get the bookmark content as plain text
 
-You can [`selectBookmark`] API to navigate to the bookmark and use [`text`] API to get the bookmark content as plain text from Document Editor component.
+You can use the [`selectBookmark`] API to navigate to the bookmark and use the [`text`] API to get the bookmark content as plain text from the Document Editor component.
 
 The following example code illustrates how to get the bookmark content as plain text.
 
@@ -23,14 +23,15 @@ The following example code illustrates how to get the bookmark content as plain 
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/get-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Get-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-To get the bookmark content as SFDT (rich text), check this [`link`](../../asp-net-core/how-to/get-the-selected-content#get-the-selected-content-as-sfdt-rich-text)
+To get the bookmark content as SFDT (rich text), check this [`link`](../../asp-net-core/how-to/get-the-selected-content#get-the-selected-content-as-sfdt-rich-text).
 
 ## Get the whole document content as text
 
-You can use [`text`] API to get the whole document content as plain text from Document Editor component.
+You can use the [`text`] API to get the whole document content as plain text from the Document Editor component.
 
 The following example code illustrates how to get the whole document content as plain text.
 
@@ -40,12 +41,13 @@ The following example code illustrates how to get the whole document content as 
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/get-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Get-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-## Get the whole document content as SFDT(rich text)
+## Get the whole document content as SFDT (rich text)
 
-You can use [`serialize`] API to get the whole document content as SFDT string from Document Editor component.
+You can use the [`serialize`] API to get the whole document content as an SFDT string from the Document Editor component.
 
 The following example code illustrates how to get the whole document content as SFDT.
 
@@ -55,12 +57,13 @@ The following example code illustrates how to get the whole document content as 
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/get-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Get-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Get the header content as text
 
-You can use [`goToHeader`] API to navigate the selection to the header and then use [`text`] API to get the content as plain text.
+You can use the [`goToHeader`] API to navigate the selection to the header and then use the [`text`] API to get the content as plain text.
 
 The following example code illustrates how to get the header content as plain text.
 
@@ -70,7 +73,8 @@ The following example code illustrates how to get the header content as plain te
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/get-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Get-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-Similarly, you can use [`goToFooter`] API to navigate the selection to the footer and then use [`text`] API to get the content as plain text.
+Similarly, you can use the [`goToFooter`] API to navigate the selection to the footer and then use the [`text`] API to get the content as plain text.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
@@ -7,7 +7,7 @@ control: Retrieve The Whole Document And Bookmark Content As Text
 documentation: ug
 ---
 
-# How to retrieve the whole document and bookmark text in DOCX Editor
+# How to retrieve the document and bookmark text in Document Editor
 
 You can get the bookmark or whole document content from the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component as plain text and SFDT (rich text).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Retrieve the document and bookmark text in DOCX Editor | Syncfusion
-description: Learn how to retrieve the whole document and bookmark content as text from the Syncfusion DOCX Editor Component
+description: Learn how to retrieve the whole document and bookmark content as text from the Syncfusion Document Editor Component
 platform: document-processing
 control: Retrieve The Whole Document And Bookmark Content As Text
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Retrieve the document and bookmark content as text in DOCX Editor
+title: Retrieve the document and bookmark text in DOCX Editor | Syncfusion
 description: Learn how to retrieve the whole document and bookmark content as text from the Syncfusion DOCX Editor Component
 platform: document-processing
 control: Retrieve The Whole Document And Bookmark Content As Text

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Show Hide Spinner in DOCX Editor Component | Syncfusion
-description: Learn here all about how to show hide spinner in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about how to show hide spinner in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Show Hide Spinner
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: Show Hide Spinner in Document Editor Component
-description: Learn here all about how to show hide spinner in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Show Hide Spinner in DOCX Editor Component | Syncfusion
+description: Learn here all about how to show hide spinner in Syncfusion DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Show Hide Spinner
 documentation: ug
 ---
 
 
-# How to show and hide spinner while opening document in React Document Editor component
+# How to show and hide spinner while opening a document in DOCX Editor
 
-Using [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide spinner while opening document in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide the spinner while opening a document in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
 ```typescript
 // showSpinner() will make the spinner visible
 showSpinner(document.getElementById('container'));
 
-// hideSpinner() method used hide spinner
+// hideSpinner() method is used to hide the spinner
 hideSpinner(document.getElementById('container'));
 ```
 
@@ -26,7 +26,8 @@ hideSpinner(document.getElementById('container'));
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/spinner/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Spinner.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-N> In above example, we have used setInterval to hide spinner, just for demo purpose.
+N> In the above example, we have used setInterval to hide spinner, just for demo purposes.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to show and hide spinner while opening a document in DOCX Editor
+# How to show or hide spinner when opening document in Document Editor
 
 Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core) component, you can show or hide the spinner while opening a document in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/show-hide-spinner.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # How to show and hide spinner while opening a document in DOCX Editor
 
-Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide the spinner while opening a document in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core) component, you can show or hide the spinner while opening a document in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
 ```typescript
 // showSpinner() will make the spinner visible


### PR DESCRIPTION
Addressing ASP.NET Core DOCX Editor ug page issues

How To ==> Override shortcut
<img width="719" height="261" alt="image" src="https://github.com/user-attachments/assets/aabde9ff-3fd9-4634-8f74-f6b83dc31932" />

How To ==> Read By default

<img width="984" height="337" alt="image" src="https://github.com/user-attachments/assets/df3bccc1-db48-412a-967e-cbcf466a11f5" />

How To ==> Resize Document editor
<img width="760" height="266" alt="image" src="https://github.com/user-attachments/assets/79d5009c-91db-4ed4-ba07-12d42ca2bdd2" />

How To ==> Retrieve document and bookmark content

<img width="766" height="276" alt="image" src="https://github.com/user-attachments/assets/c271a6bf-8c0c-4500-baa9-117ef88d654b" />

How To ==> Hide spinner
<img width="668" height="276" alt="image" src="https://github.com/user-attachments/assets/a905aafb-a881-4d3e-8f68-818cd0a4a756" />




