### PR TITLE
Task(1045767): Addressing ASP.NET MVC DOCX Editor ug documentation issues

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: Document Management in ASP.NET MVC Document Editor Component
-description: Learn here all about Document Management in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Document Management in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about Document Management in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Document Management
 documentation: ug
 ---
 
 
-# Document management in Document Editor Component
+# Document management in DOCX Editor Component
 
-Document Editor provides support to restrict editing. When the protected document includes range permission, then unique user or user group is only authorized to edit separate text area.
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) provides support to restrict editing. When the protected document includes range permissions, only a unique user or user group is authorized to edit a separate text area.
 
-## Set current user
+## Set the current user
 
 You can use the `currentUser` property to authorize the current document user by name, email, or user group name.
 
-The following code shows how to set currentUser
+The following code shows how to set `currentUser`.
 
 ```typescript
 container.documentEditor.currentUser = 'engineer@mycompany.com';
@@ -26,7 +26,7 @@ container.documentEditor.currentUser = 'engineer@mycompany.com';
 
 You can highlight the editable region of the current user using the `userColor` property.
 
-The following code shows how to set userColor.
+The following code shows how to set `userColor`.
 
 ```typescript
 container.documentEditor.userColor = '#fff000';
@@ -34,15 +34,15 @@ container.documentEditor.userColor = '#fff000';
 
 ## Restrict Editing Pane
 
-Restrict Editing Pane provides the following options to manage the document:
+The Restrict Editing pane provides the following options to manage the document:
 
 * To apply formatting restrictions to the current document, select the allow formatting check box.
-* To apply editing restrictions to the current document, select the read only check box.
-* To add users to the current document, select more users option and add user from the popup dialog.
-* To include range permission to the current document, select parts of the document and choose users who are allowed to freely edit them from the listed check box.
-* To apply the chosen editing restrictions, click the **YES,START ENFORCING PROTECTION** button. A dialog box displays asking for a password to protect.
-* To stop protection, select **STOP PROTECTION** button. A dialog box displays asking for a password to stop protection.
+* To apply editing restrictions to the current document, select the read-only check box.
+* To add users to the current document, select the more users option and add a user from the popup dialog.
+* To include range permissions in the current document, select parts of the document and choose users who are allowed to freely edit them from the listed check box.
+* To apply the chosen editing restrictions, click the **YES, START ENFORCING PROTECTION** button. A dialog box displays asking for a password to protect.
+* To stop protection, select the **STOP PROTECTION** button. A dialog box displays asking for a password to stop protection.
 
-* [How to protect the document in form filling mode](./form-fields.md/#protect-the-document-in-form-filling-mode)
-* [How to protect the document in comments only mode](./comments.md/#protect-the-document-in-comments-only-mode)
-* [How to protect the document in track changes only mode](./track-changes.md/#protect-the-document-in-track-changes-only-mode)
+* [How to protect the document in form-filling mode](./form-fields.md/#protect-the-document-in-form-filling-mode)
+* [How to protect the document in comments-only mode](./comments.md/#protect-the-document-in-comments-only-mode)
+* [How to protect the document in track-changes-only mode](./track-changes.md/#protect-the-document-in-track-changes-only-mode)

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Document management in DOCX Editor Component
+# Document management in Document Editor Component
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) provides support to restrict editing. When the protected document includes range permissions, only a unique user or user group is authorized to edit a separate text area.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
@@ -43,6 +43,6 @@ The Restrict Editing pane provides the following options to manage the document:
 * To apply the chosen editing restrictions, click the **YES, START ENFORCING PROTECTION** button. A dialog box displays asking for a password to protect.
 * To stop protection, select the **STOP PROTECTION** button. A dialog box displays asking for a password to stop protection.
 
-* [How to protect the document in form-filling mode](./form-fields.md/#protect-the-document-in-form-filling-mode)
-* [How to protect the document in comments-only mode](./comments.md/#protect-the-document-in-comments-only-mode)
-* [How to protect the document in track-changes-only mode](./track-changes.md/#protect-the-document-in-track-changes-only-mode)
+* [How to protect the document in form-filling mode](./form-fields.md#protect-the-document-in-form-filling-mode)
+* [How to protect the document in comments-only mode](./comments.md#protect-the-document-in-comments-only-mode)
+* [How to protect the document in track-changes-only mode](./track-changes.md#protect-the-document-in-track-changes-only-mode)

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/document-management.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Document Management in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about Document Management in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Document Management in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Document Management
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
@@ -7,7 +7,7 @@ control: Unsupported file
 documentation: ug
 ---
 
-# Why Do I Get the Unsupported Warning Message When Opening a Document in ASP.NET MVC?
+# Why Do I Get an Unsupported Warning When Opening Docs in ASP.NET MVC?
 
 If you receive the "The file format you have selected isn't supported. Please choose a valid format." message when opening a document in the DOCX Editor, it typically indicates that the document format is not supported by the current version of the DOCX Editor. Here are some common reasons for this warning:
 1.	Unsupported File Format: The document you are trying to open might be in a format that the DOCX Editor does not support. Ensure you are using a supported format, such as SFDT.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Unsupported file in ASP.NET MVC Document Editor Component | Syncfusion
-description: Learn here all about Unsupported file in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Unsupported file in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about Unsupported file in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Unsupported file
 documentation: ug
@@ -9,12 +9,12 @@ documentation: ug
 
 # Why Do I Get the Unsupported Warning Message When Opening a Document in ASP.NET MVC?
 
-If you receive an "The file format you have selected isn't supported. Please choose valid format." message when opening a document in the Document Editor, it typically indicates that the document format is not supported by the current version of the Document Editor. Here are some common reasons for this warning:
-1.	Unsupported File Format: The document you are trying to open might be in a format that the Document Editor does not support. Ensure you are using a supported format, such as SFDT.
+If you receive the "The file format you have selected isn't supported. Please choose a valid format." message when opening a document in the DOCX Editor, it typically indicates that the document format is not supported by the current version of the DOCX Editor. Here are some common reasons for this warning:
+1.	Unsupported File Format: The document you are trying to open might be in a format that the DOCX Editor does not support. Ensure you are using a supported format, such as SFDT.
 2.	Corrupted Document: The document file might be corrupted or improperly formatted. Try opening a different document to see if the issue persists.
-To avoid this warning, always use the recommended document formats and features supported by the Document Editor. 
+To avoid this warning, always use the recommended document formats and features supported by the DOCX Editor. 
 
-Document Editor supports the following file formats:
+DOCX Editor supports the following file formats:
 •	Word Document (*.docx)
 •	Syncfusion Document Text (*.sfdt)
 •	Plain Text (*.txt)
@@ -25,4 +25,4 @@ Document Editor supports the following file formats:
 •	Word 97-2003 Template (*.dot)
 •	Word 97-2003 Document (*.doc)
 
-By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the Document Editor.
+By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
@@ -9,12 +9,12 @@ documentation: ug
 
 # Why Do I Get an Unsupported Warning When Opening Docs in ASP.NET MVC?
 
-If you receive the "The file format you have selected isn't supported. Please choose a valid format." message when opening a document in the DOCX Editor, it typically indicates that the document format is not supported by the current version of the DOCX Editor. Here are some common reasons for this warning:
-1.	Unsupported File Format: The document you are trying to open might be in a format that the DOCX Editor does not support. Ensure you are using a supported format, such as SFDT.
+If you receive the "The file format you have selected isn't supported. Please choose a valid format." message when opening a document in the Document Editor, it typically indicates that the document format is not supported by the current version of the Document Editor. Here are some common reasons for this warning:
+1.	Unsupported File Format: The document you are trying to open might be in a format that the Document Editor does not support. Ensure you are using a supported format, such as SFDT.
 2.	Corrupted Document: The document file might be corrupted or improperly formatted. Try opening a different document to see if the issue persists.
-To avoid this warning, always use the recommended document formats and features supported by the DOCX Editor. 
+To avoid this warning, always use the recommended document formats and features supported by the Document Editor. 
 
-DOCX Editor supports the following file formats:
+Document Editor supports the following file formats:
 •	Word Document (*.docx)
 •	Syncfusion Document Text (*.sfdt)
 •	Plain Text (*.txt)
@@ -25,4 +25,4 @@ DOCX Editor supports the following file formats:
 •	Word 97-2003 Template (*.dot)
 •	Word 97-2003 Document (*.doc)
 
-By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the DOCX Editor.
+By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the Document Editor.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/faq/unsupported-file-format.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Unsupported file in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about Unsupported file in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Unsupported file in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Unsupported file
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Feature modules
+# Feature modules in ASP.NET MVC DOCX Editor
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the DOCX Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of the DOCX Editor that can be included as required:
 * **Print** - Prints the document.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Feature Module in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about Feature Module in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Feature Module in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Feature Module
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
@@ -8,9 +8,9 @@ documentation: ug
 ---
 
 
-# Feature modules in ASP.NET MVC DOCX Editor
+# Feature modules in ASP.NET MVC Document Editor
 
-[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the DOCX Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of the DOCX Editor that can be included as required:
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the Document Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of the Document Editor that can be included as required:
 * **Print** - Prints the document.
 * **SfdtExport** - Exports the document as a Syncfusion Document Text (.sfdt) file.
 * **Selection** - Selects a portion of the document and copies it to the clipboard.
@@ -21,11 +21,11 @@ documentation: ug
 * **EditorHistory** - Maintains the history of editing operations so that you can perform undo and redo at any time.
 * User interface options such as context menu, options pane, image resizer, and dialog are available as individual modules.
 
-N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a DOCX Editor instance.
+N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a Document Editor instance.
 
 Refer to the following table.
 
-| Module |  Property to enable the functionality for a DOCX Editor instance |
+| Module |  Property to enable the functionality for a Document Editor instance |
 |---|---|---|
 |Print|`@Html.EJS().DocumentEditor("container").EnablePrint(true).Render()`|
 |SfdtExport|`@Html.EJS().DocumentEditor("container").EnableSfdtExport(true).Render()`|

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Feature Module in ASP.NET MVC DOCX Editor Component
+title: Feature Module in ASP.NET MVC DOCX Editor Component | Syncfusion
 description: Learn here all about Feature Module in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Feature Module

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/feature-module.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Feature Module in ASP.NET MVC Document Editor Component
-description: Learn here all about Feature Module in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Feature Module in ASP.NET MVC DOCX Editor Component
+description: Learn here all about Feature Module in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Feature Module
 documentation: ug
@@ -10,22 +10,22 @@ documentation: ug
 
 # Feature modules
 
-Document editor features are segregated into individual feature-wise modules to enable selective referencing. By default, the document editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of document editor that can be included as required:
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the DOCX Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of the DOCX Editor that can be included as required:
 * **Print** - Prints the document.
-* **SfdtExport** - Exports the document as Syncfusion Document Text (.SFDT) file.
-* **Selection** - Selects a portion of the document and copy it to the clipboard.
-* **Search** - Searches specific text and navigate between the results.
-* **WordExport** - Exports the document as Word Document (.DOCX) file.
-* **TextExport** - Exports the document as Text Document (.TXT) file.
-* **Editor** - Performs all kind of editing operations.
+* **SfdtExport** - Exports the document as a Syncfusion Document Text (.sfdt) file.
+* **Selection** - Selects a portion of the document and copies it to the clipboard.
+* **Search** - Searches for specific text and navigates between the results.
+* **WordExport** - Exports the document as a Word Document (.docx) file.
+* **TextExport** - Exports the document as a Text Document (.txt) file.
+* **Editor** - Performs all kinds of editing operations.
 * **EditorHistory** - Maintains the history of editing operations so that you can perform undo and redo at any time.
 * User interface options such as context menu, options pane, image resizer, and dialog are available as individual modules.
 
-N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a document editor instance.
+N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a DOCX Editor instance.
 
 Refer to the following table.
 
-| Module |  Property to Enable the functionality for a document editor instance |
+| Module |  Property to enable the functionality for a DOCX Editor instance |
 |---|---|---|
 |Print|`@Html.EJS().DocumentEditor("container").EnablePrint(true).Render()`|
 |SfdtExport|`@Html.EJS().DocumentEditor("container").EnableSfdtExport(true).Render()`|

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
@@ -7,13 +7,13 @@ control: Fields
 documentation: ug
 ---
 
-# Fields
+# Fields in ASP.NET MVC DOCX Editor
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) has preservation support for all types of fields in an existing Word document without any data loss.
 
 ## Adding Fields
 
-You can add a field to the document by using the [`insertField`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#insertfield) method in the `Editor` module.
+You can add a field to the document by using the [`insertField`](https://ej2.syncfusion.com/documentation/api/document-editor/editor#insertfield) method in the `Editor` module.
 
 ```typescript
 
@@ -46,7 +46,7 @@ The following types of fields are automatically updated in DOCX Editor.
 
 ## Get field info
 
-You can get the field code and field result of the currently selected field by using the [`getFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/selection/#getfieldinfo) method in the `Selection` module.
+You can get the field code and field result of the currently selected field by using the [`getFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/selection#getfieldinfo) method in the `Selection` module.
 
 ```typescript
 //Gets the field information of the selected field.
@@ -57,7 +57,7 @@ N> For nested fields, this method returns the combined field code and result.
 
 ## Set field info
 
-You can modify the field code and field result of the currently selected field by using the [`setFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#setfieldinfo) method in the `Editor` module.
+You can modify the field code and field result of the currently selected field by using the [`setFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/editor#setfieldinfo) method in the `Editor` module.
 
 ```typescript
 //Get the field information for the selected field.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fields in ASP.NET MVC DOCX Editor Control | Syncfusion
-description: Learn here all about Fields in Syncfusion ASP.NET MVC DOCX Editor control of Syncfusion Essential JS 2 and more.
+description: Learn here all about Fields in Syncfusion ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Fields
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
@@ -1,16 +1,19 @@
 ---
-title: "Fields"
-component: "DocumentEditor"
-description: "Learn how to use fields in JavaScript document editor"
+layout: post
+title: Fields in ASP.NET MVC DOCX Editor Control | Syncfusion
+description: Learn here all about Fields in Syncfusion ASP.NET MVC DOCX Editor control of Syncfusion Essential JS 2 and more.
+platform: document-processing
+control: Fields
+documentation: ug
 ---
 
 # Fields
 
-Document Editor has preservation support for all types of fields in an existing word document without any data loss.
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) has preservation support for all types of fields in an existing Word document without any data loss.
 
 ## Adding Fields
 
-You can add a field to the document by using [`insertField`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#insertfield) method in `Editor` module.
+You can add a field to the document by using the [`insertField`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#insertfield) method in the `Editor` module.
 
 ```typescript
 
@@ -20,22 +23,22 @@ documenteditor.editor.insertField(fieldCode, fieldResult);
 
 ```
 
-N> Document editor does not validate or process the field code or field result. It simply inserts the field with specified field information.
+N> DOCX Editor does not validate or process the field code or field result. It simply inserts the field with the specified field information.
 
 ## Update fields
 
-Document Editor provides support for updating bookmark cross reference field.
+DOCX Editor provides support for updating bookmark cross reference fields.
 
 ```typescript
-//Update all the bookmark cross reference field in the document.
+//Update all the bookmark cross reference fields in the document.
 documenteditor.updateFields();
 ```
 
-Bookmark cross reference fields can be updated through UI by using update fields option in `Toolbar`.
+Bookmark cross reference fields can be updated through the UI by using the update fields option in `Toolbar`.
 
-![Update bookmark cross reference field.](images/updatefields.png)
+![Update bookmark cross reference fields.](images/updatefields.png)
 
-The following type of fields are automatically updated in Document Editor.
+The following types of fields are automatically updated in DOCX Editor.
 
 * NUMPAGES
 * SECTION
@@ -43,21 +46,21 @@ The following type of fields are automatically updated in Document Editor.
 
 ## Get field info
 
-You can get field code and field result of the current selected field by using [`getFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/selection/#getfieldinfo) method in the `Selection` module.
+You can get the field code and field result of the currently selected field by using the [`getFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/selection/#getfieldinfo) method in the `Selection` module.
 
 ```typescript
 //Gets the field information of the selected field.
 var fieldInfo = documenteditor.selection.getFieldInfo();
 ```
 
-N> For nested fields, this method returns combined field code and result.
+N> For nested fields, this method returns the combined field code and result.
 
 ## Set field info
 
-You can modify the field code and field result of the current selected field by using [`setFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#setfieldinfo) method in the `Editor` module.
+You can modify the field code and field result of the currently selected field by using the [`setFieldInfo`](https://ej2.syncfusion.com/documentation/api/document-editor/editor/#setfieldinfo) method in the `Editor` module.
 
 ```typescript
-//Gets the field information for the selected field.
+//Get the field information for the selected field.
 var fieldInfo = documenteditor.selection.getFieldInfo();
 
 //Modify field code
@@ -66,11 +69,11 @@ fieldInfo.code = 'MERGEFIELD  First Name  \\* MERGEFORMAT ';
 //Modify field result
 fieldInfo.result = '«First Name»';
 
-//Modify field code and result of the current selected field.
+//Modify field code and result of the currently selected field.
 documenteditor.editor.setFieldInfo(fieldInfo);
 ```
 
-N> For nested field, entire field gets replaced completely with the specified field information.
+N> For a nested field, the entire field is replaced completely with the specified field information.
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/fields.md
@@ -7,7 +7,7 @@ control: Fields
 documentation: ug
 ---
 
-# Fields in ASP.NET MVC DOCX Editor
+# Fields in ASP.NET MVC Document Editor
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) has preservation support for all types of fields in an existing Word document without any data loss.
 
@@ -23,11 +23,11 @@ documenteditor.editor.insertField(fieldCode, fieldResult);
 
 ```
 
-N> DOCX Editor does not validate or process the field code or field result. It simply inserts the field with the specified field information.
+N> Document Editor does not validate or process the field code or field result. It simply inserts the field with the specified field information.
 
 ## Update fields
 
-DOCX Editor provides support for updating bookmark cross reference fields.
+Document Editor provides support for updating bookmark cross reference fields.
 
 ```typescript
 //Update all the bookmark cross reference fields in the document.
@@ -38,7 +38,7 @@ Bookmark cross reference fields can be updated through the UI by using the updat
 
 ![Update bookmark cross reference fields.](images/updatefields.png)
 
-The following types of fields are automatically updated in DOCX Editor.
+The following types of fields are automatically updated in Document Editor.
 
 * NUMPAGES
 * SECTION

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Find And Replace in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about find and replace in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about find and replace in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Find And Replace
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Find and Replace in ASP.NET MVC DOCX Editor Component
+# Find and Replace in ASP.NET MVC Document Editor Component
 
 The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor)  component searches for a portion of text in the document through a built-in interface called `OptionsPane` or rich APIs. When used in combination with selection, it performs various operations on the search results like replacing it with some other text, highlighting it, making it bold, and more.
 
@@ -34,7 +34,7 @@ You can close the options pane by pressing the `Esc` key.
 
 ## Search
 
-The `Search` module of the DOCX Editor exposes the following APIs:
+The `Search` module of the Document Editor exposes the following APIs:
 
 |API Name|Type |Description|
 |---|---|---|

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/find-and-replace.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Find And Replace in ASP.NET MVC Document Editor Component | Syncfusion
-description: Learn here all about find and replace in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Find And Replace in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about find and replace in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Find And Replace
 documentation: ug
 ---
 
 
-# Find and Replace in ASP.NET MVC in Document Editor Component
+# Find and Replace in ASP.NET MVC DOCX Editor Component
 
-The document editor component searches a portion of text in the document through a built-in interface called `OptionsPane` or rich APIs. When used in combination with selection performs various operations on the search results like replacing it with some other text, highlighting it, making it bolder, and more.
+The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor)  component searches for a portion of text in the document through a built-in interface called `OptionsPane` or rich APIs. When used in combination with selection, it performs various operations on the search results like replacing it with some other text, highlighting it, making it bold, and more.
 
 ## Options pane
 
-This provides the options to search for a portion of text in the document. After search operation is completed, the search results will be displayed in a list and options to navigate between them. The current occurrence of matched text or all occurrences with another text can be replaced by switching to `Replace` tab. This pane is opened using the keyboard shortcut `CTRL+F`.
+This provides options to search for a portion of text in the document. After the search operation is completed, the search results will be displayed in a list with options to navigate between them. The current occurrence of matched text or all occurrences can be replaced with other text by switching to the `Replace` tab. This pane is opened using the keyboard shortcut `Ctrl+F`.
 
 
 
@@ -30,52 +30,52 @@ This provides the options to search for a portion of text in the document. After
 
 
 
-You can close the options pane by pressing `Esc` key.
+You can close the options pane by pressing the `Esc` key.
 
 ## Search
 
-The `Search` module of Document Editor exposes the following APIs:
+The `Search` module of the DOCX Editor exposes the following APIs:
 
 |API Name|Type |Description|
 |---|---|---|
 |`findAll()` | Method |Searches for specified text in the whole document and highlights it with yellow.|
 |`searchResults` |Property |This is an instance of `SearchResults`.|
-|`find()` | Method |Find immediate occurrence of specified text from cursor position in the document and highlights it with yellow.|
+|`find()` | Method |Finds the immediate occurrence of specified text from the cursor position in the document and highlights it with yellow.|
 
 ### Find the immediate occurrence in the document
 
-Using `find()` method, you can find the immediate occurrence of specified text from current cursor position in the document.
+Using the `find()` method, you can find the immediate occurrence of specified text from the current cursor position in the document.
 
 ```typescript
 documenteditor.search.find('Some text', 'None');
 ```
 
-N> Second parameter is optional parameter and it denotes find Options. Possible values of find options are `'None' |'WholeWord' |'CaseSensitive'| 'CaseSensitiveWholeWord'`.
+N> The second parameter is an optional parameter and it denotes find options. Possible values of find options are `'None' |'WholeWord' |'CaseSensitive'| 'CaseSensitiveWholeWord'`.
 
 ### Find all the occurrences in the document
 
-Using `findAll()` method, you can find all the occurrences of specified text in the whole document and highlight it with yellow.
+Using the `findAll()` method, you can find all the occurrences of specified text in the whole document and highlight them with yellow.
 
 ```typescript
 documenteditor.search.findAll('Some text', 'None');
 ```
 
-N> Second parameter is optional parameter and it denotes to find Options. Possible values of find options are `'None' |'WholeWord' |'CaseSensitive'| 'CaseSensitiveWholeWord'`.
+N> The second parameter is an optional parameter and it denotes find options. Possible values of find options are `'None' |'WholeWord' |'CaseSensitive'| 'CaseSensitiveWholeWord'`.
 
 ## Search results
 
-The `SearchResults` class provides information about the search results after search operation is completed that can be identified using the `searchResultsChange` event. This will expose the following APIs:
+The `SearchResults` class provides information about the search results after the search operation is completed, which can be identified using the `searchResultsChange` event. This will expose the following APIs:
 
 |API Name|Type |Description|
 |---|---|---|
 |`length` |Property|Returns the total number of results found on the search.|
 |`index` |Property|Returns the index of selected search result. You can change the value for this property to move the selection.|
-|`replaceAll()` |Method|Replaces all the occurrences with specified text.|
-|`clear()` |Method|Clears the search result.|
+|`replaceAll()` |Method|Replaces all the occurrences with the specified text.|
+|`clear()` |Method|Clears the search results.|
 
 ### Replace all the occurrences
 
-Using `replaceAll`, you can replace all the occurrences with specified text.
+Using `replaceAll`, you can replace all the occurrences with the specified text.
 
 ```typescript
 documentEditor.search.findAll ('Some text');
@@ -85,12 +85,12 @@ documentEditor.search.searchResults.replaceAll("Mike");
 
 ### Replace
 
-Using `insertText`, you can replace the current searched text with specified text and it replaces single occurrence.
+Using `insertText`, you can replace the currently searched text with the specified text and it replaces a single occurrence.
 
-N>Note: This `insertText` API accepts following control characters.
+N>This `insertText` API accepts the following control characters.
 <br/>* New line characters ("\r", "\r\n", "\n") - Inserts a new paragraph and appends the remaining text to the new paragraph.
-<br/>* Line break character ("\v") - Moves the remaining text to start in new line.
-<br/>* Tab character ("\t") - Allocates a tab space and continue the next character.
+<br/>* Line break character ("\v") - Moves the remaining text to start in a new line.
+<br/>* Tab character ("\t") - Allocates a tab space and continues with the next character.
 
 ```typescript
 container.documentEditor.search.findAll('works');
@@ -98,7 +98,7 @@ container.documentEditor.search.findAll('works');
 let searchLength: number = container.documentEditor.search.searchResults.length;
 
 for (let i = searchLength - 1; i >= 0; i--) {
-  // It will move selection to specific searched index,move to each occurrence one by one
+  // It will move selection to specific searched index, move to each occurrence one by one
   container.documentEditor.search.searchResults.index = i;
   // Replace it with some text
   container.documentEditor.editor.insertText('Hello');
@@ -109,14 +109,14 @@ container.documentEditor.search.searchResults.clear();
 
 ## SearchResultsChange event
 
-`DocumentEditor` exposes the `searchResultsChange’`event that will be triggered whenever search results are changed. Consider the following scenarios:
+`DocumentEditor` exposes the `searchResultsChange` event that will be triggered whenever search results are changed. Consider the following scenarios:
 
 * A search operation is completed with some results.
-* The results are replaced with some other text, since it will be cleared automatically.
+* The results are replaced with some other text, which will be cleared automatically.
 * The results are cleared explicitly.
 
 ```typescript
-documenteditor.searchResultsChange = function() {
+documentEditor.searchResultsChange = function() {
 
 };
 ```

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: Form Fields in ASP.NET MVC Document Editor Control | Syncfusion
-description: Learn here all about Form Fields in Syncfusion ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more.
+title: Form Fields in ASP.NET MVC DOCX Editor Control | Syncfusion
+description: Learn here all about Form Fields in Syncfusion ASP.NET MVC DOCX Editor control of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Form Fields
 documentation: ug
 ---
 
 
-# Form Fields in ASP.NET MVC in Document Editor Control
+# Form Fields in ASP.NET MVC DOCX Editor Control
 
-DocumentEditorContainer control provides support for inserting Text, CheckBox, DropDown form fields through in-built toolbar.
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) provides support for inserting Text, CheckBox, and DropDown form fields through the built-in toolbar.
 
 ![Form Fields](images/toolbar-form-fields.png)
 
 ## Insert form field
 
-Form fields can be inserted using `insertFormField` method in editor module.
+Form fields can be inserted using the `insertFormField` method in the editor module.
 
 ```typescript
 //Insert Text form field
@@ -29,7 +29,7 @@ documentEditor.editor.insertFormField('Dropdown');
 
 ## Get form field names
 
-All the form fields names from current document can be retrieved using `getFormFieldNames()`.
+All the form field names from the current document can be retrieved using `getFormFieldNames()`.
 
 ```typescript
 var formFieldsNames = documentEditor.getFormFieldNames();
@@ -65,18 +65,18 @@ var checkboxfieldInfo = documentEditor.getFormFieldInfo('Check1');
 checkboxfieldInfo.defaultValue = true;
 documentEditor.setFormFieldInfo('Check1',checkboxfieldInfo);
 
-// Set checkbox form field properties
+// Set dropdown form field properties
 var dropdownfieldInfo = documentEditor.getFormFieldInfo('Drop1');
-dropdownfieldInfo.dropDownItems = ['One','Two', 'Three']
+dropdownfieldInfo.dropDownItems = ['One','Two', 'Three'];
 documentEditor.setFormFieldInfo('Drop1',dropdownfieldInfo);
 ```
 
 ## Export form field data
 
-Data of the all Form fields in the document can be exported using `exportFormData`.
+Data of all the form fields in the document can be exported using `exportFormData`.
 
 ```typescript
-var formFieldDate = documentEditor.exportFormData();
+var formFieldData = documentEditor.exportFormData();
 ```
 
 ## Import form field data
@@ -93,7 +93,7 @@ documentEditor.importFormData([textformField,checkformField,dropdownformField]);
 
 ## Reset form fields
 
-Reset all the form fields in current document to default value using `resetFormFields`.
+Reset all the form fields in the current document to their default values using `resetFormFields`.
 
 ```typescript
 documentEditor.resetFormFields();
@@ -101,9 +101,9 @@ documentEditor.resetFormFields();
 
 ## Protect the document in form filling mode
 
-Document Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, user can only fill form fields in the document.
+DOCX Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
 
-Document editor provides an option to protect and unprotect document using `enforceProtection` and `stopProtection` API.
+DOCX Editor provides an option to protect and unprotect the document using `enforceProtection` and `stopProtection` API.
 
 
 
@@ -112,11 +112,12 @@ Document editor provides an option to protect and unprotect document using `enfo
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/protect-unprotect/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Protect-unprotect.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-N> In enforce Protection method, first parameter denotes password and second parameter denotes protection type. Possible values of protection type are `NoProtection |ReadOnly |FormFieldsOnly |CommentsOnly`. In stop protection method, parameter denotes the password.
+N> In the enforceProtection method, the first parameter denotes the password and the second parameter denotes the protection type. Possible values of protection type are `NoProtection |ReadOnly |FormFieldsOnly |CommentsOnly`. In the stopProtection method, the parameter denotes the password.
 
 ## Online Demo
 
-Explore how to insert and manage form fields in Word documents using the ASP.NET MVC Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/formfields#/tailwind3).
+Explore how to insert and manage form fields in Word documents using the ASP.NET MVC DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/formfields#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Form Fields in ASP.NET MVC DOCX Editor Control
+# Form Fields in ASP.NET MVC Document Editor Control
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) provides support for inserting Text, CheckBox, and DropDown form fields through the built-in toolbar.
 
@@ -101,9 +101,9 @@ documentEditor.resetFormFields();
 
 ## Protect the document in form filling mode
 
-DOCX Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
+Document Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
 
-DOCX Editor provides an option to protect and unprotect the document using `enforceProtection` and `stopProtection` API.
+Document Editor provides an option to protect and unprotect the document using `enforceProtection` and `stopProtection` API.
 
 
 
@@ -120,4 +120,4 @@ N> In the enforceProtection method, the first parameter denotes the password and
 
 ## Online Demo
 
-Explore how to insert and manage form fields in Word documents using the ASP.NET MVC DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/formfields#/tailwind3).
+Explore how to insert and manage form fields in Word documents using the ASP.NET MVC Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/formfields#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/form-fields.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Form Fields in ASP.NET MVC DOCX Editor Control | Syncfusion
-description: Learn here all about Form Fields in Syncfusion ASP.NET MVC DOCX Editor control of Syncfusion Essential JS 2 and more.
+description: Learn here all about Form Fields in Syncfusion ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Form Fields
 documentation: ug


### PR DESCRIPTION
Addressing ASP.NET MVC DOCX Editor ug documentation issues

FAQ ==> Unsupported file format

<img width="638" height="303" alt="image" src="https://github.com/user-attachments/assets/96eeea48-9bb3-479d-bfa3-3c088698b937" />

Feature
<img width="638" height="279" alt="image" src="https://github.com/user-attachments/assets/d48ad938-1a94-4da2-a699-3190fa41668e" />

Fields
<img width="633" height="263" alt="image" src="https://github.com/user-attachments/assets/449002fc-53f8-4156-8ea6-a317d4dd3366" />

Find and replace
<img width="936" height="277" alt="image" src="https://github.com/user-attachments/assets/edf2f714-b675-4794-b0c3-04474af79e54" />

Form Field
<img width="717" height="280" alt="image" src="https://github.com/user-attachments/assets/c9852f49-1240-4710-be0d-327ac468eaee" />

Document management
<img width="712" height="280" alt="image" src="https://github.com/user-attachments/assets/3d1f3ecb-a581-433e-adfd-fb71f8dc6a4a" />



