### PR TITLE
Task(1045767): Addressing the ASP.NET MVC DOCX Editor ug documentation issue

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/getting-started.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/getting-started.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Getting Started with ASP.NET MVC DOCX Editor
 
-Syncfusion<sup style="font-size:70%">&reg;</sup> [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) enables you to create, edit, view, and print Word documents in web applications. This section guides you through the steps to get started and create a DOCX Editor in an ASP.NET MVC application. 
+Syncfusion<sup style="font-size:70%">&reg;</sup> [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) enables you to create, edit, view, and print Word documents in web applications. This section guides you through the steps to get started and create a DOCX Editor in an ASP.NET MVC application.
 
 ## Prerequisites
 
@@ -25,8 +25,8 @@ Syncfusion<sup style="font-size:70%">&reg;</sup> [ASP.NET MVC DOCX Editor](https
 ## Install Syncfusion<sup style="font-size:70%">&reg;</sup> ASP.NET MVC NuGet packages
 
 To add the DOCX Editor component in the application, follow the steps below.
-- Open NuGet package manager in Visual Studio (*Tools → NuGet Package Manager → Manage NuGet Packages for Solution*), 
-- Search and install the following package
+- Open NuGet package manager in Visual Studio (*Tools → NuGet Package Manager → Manage NuGet Packages for Solution*).
+- Search and install the following package.
     - [Syncfusion.EJ2.MVC5](https://www.nuget.org/packages/Syncfusion.EJ2.MVC5)
 
 
@@ -63,7 +63,7 @@ Before initializing the ASP.NET MVC DOCX Editor control, generate a Syncfusion l
 
 ## Add the stylesheet and script resources
 
-To render Syncfusion ASP.NET MVC controls with the expected appearance, reference the theme stylesheet and the control scripts via CDN inside the `<head>` of the `~/Views/Shared/_Layout.cshtml` file as follows,
+To render Syncfusion ASP.NET MVC controls with the expected appearance, reference the theme stylesheet and the control scripts via CDN inside the `<head>` of the `~/Views/Shared/_Layout.cshtml` file as follows.
 
 {% tabs %}
 {% highlight cshtml tabtitle="~/_Layout.cshtml" %}
@@ -76,7 +76,7 @@ To render Syncfusion ASP.NET MVC controls with the expected appearance, referenc
 {% endhighlight %}
 {% endtabs %}
 
-N> Refer the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn the different ways to include Syncfusion styles (using [CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), or [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) and ensure the expected appearance of Syncfusion<sup style="font-size:70%">&reg;</sup> ASP.NET MVC controls, and check the [Adding Script Reference](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references) documentation to understand the various approaches for adding required script references in your ASP.NET MVC application.
+N> Refer to the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn the different ways to include Syncfusion styles (using [CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), or [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) and ensure the expected appearance of Syncfusion<sup style="font-size:70%">&reg;</sup> ASP.NET MVC controls, and check the [Adding Script Reference](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references) documentation to understand the various approaches for adding required script references in your ASP.NET MVC application.
 
 ## Register script manager
 
@@ -93,7 +93,7 @@ Register the Script Manager at the end of the `<body>` tag in the `~/Views/Share
 
 ## Add the DOCX Editor Component
 
-Add the DOCX Editor component in `~/Views/Home/Index.cshtml` page.
+Add the DOCX Editor component to the `~/Views/Home/Index.cshtml` page.
 
 {% tabs %}
 {% highlight cshtml tabtitle="~/Index.cshtml" %}
@@ -103,7 +103,7 @@ Add the DOCX Editor component in `~/Views/Home/Index.cshtml` page.
 
 ## Run the application
 
-Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app. The DOCX Editor component will then be rendered in the default web browser as shown below.
+Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app. The DOCX Editor component will render in the default web browser as shown below.
 
 ![Output of ASP.NET MVC DOCX Editor](./images/aspnetmvc-docx-editor.png)
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
@@ -8,17 +8,17 @@ documentation: ug
 ---
 
 
-# Globalization in ASP.NET MVC DOCX Editor Component
+# Globalization in ASP.NET MVC Document Editor Component
 
 ## Localization
 
-The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows you to localize the default text content of the DocumentEditor. The DOCX Editor component has static text in some features (like find & replace, context menu, dialogs) that can be changed to other cultures (Arabic, Deutsch, French, etc.) by defining the locale value and translation object. Refer to the sample link [RTL](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
+The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows you to localize the default text content of the DocumentEditor. The Document Editor component has static text in some features (like find & replace, context menu, dialogs) that can be changed to other cultures (Arabic, Deutsch, French, etc.) by defining the locale value and translation object. Refer to the sample link [RTL](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
 
 N> Refer to the [Locale](https://github.com/syncfusion/ej2-locale).
 
 ## Document Editor
 
-The following list of properties and their values are used in the DOCX Editor.
+The following list of properties and their values are used in the Document Editor.
 
 Locale keywords |Text
 -----|-----

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
@@ -1,24 +1,24 @@
 ---
 layout: post
-title: Global Local in Syncfusion ASP.NET MVC Document Editor Component
-description: Learn here all about Global Local in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Global Local in Syncfusion ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn here all about Global Local in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Global Local
 documentation: ug
 ---
 
 
-# Globalization in ASP.NET MVC in Document Editor Component
+# Globalization in ASP.NET MVC DOCX Editor Component
 
 ## Localization
 
-The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows to localize default text content of the DocumentEditor. The document editor component has static text on some features (like find & replace, context-menu, dialogs) that can be changed to other cultures (Arabic, Deutsch, French, etc.) by defining the locale value and translation object. Refer the sample link [RTL](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
+The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows you to localize the default text content of the DocumentEditor. The DOCX Editor component has static text in some features (like find & replace, context menu, dialogs) that can be changed to other cultures (Arabic, Deutsch, French, etc.) by defining the locale value and translation object. Refer to the sample link [RTL](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
 
-N> Refer the [Locale](https://github.com/syncfusion/ej2-locale).
+N> Refer to the [Locale](https://github.com/syncfusion/ej2-locale).
 
 ## Document Editor
 
-The following list of properties and its values are used in the document editor.
+The following list of properties and their values are used in the DOCX Editor.
 
 Locale keywords |Text
 -----|-----
@@ -365,7 +365,7 @@ View | View
 
 ## Document Editor Container
 
-The following list of properties and its values are used in the document editor container.
+The following list of properties and their values are used in the Document Editor container.
 
 Locale keywords |Text
 -----|-----
@@ -518,7 +518,7 @@ Show properties pane | Show properties pane
 
 ## Color Picker
 
-The following list of properties and its values are used in the color picker.
+The following list of properties and their values are used in the color picker.
 
 Locale keywords | Text
 -----|-----

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/global-local.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Global Local in Syncfusion ASP.NET MVC DOCX Editor | Syncfusion
-description: Learn here all about Global Local in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Global Local in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Global Local
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Header Footer in ASP.NET MVC Document Editor Component
-description: Learn here all about Header Footer in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Header Footer in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about Header Footer in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Header Footer
 documentation: ug
@@ -10,24 +10,24 @@ documentation: ug
 
 # Headers and Footers
 
-Document editor supports headers and footers in its document. Each section in the document can have the following types of headers and footers:
+The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor)  supports headers and footers in its documents. Each section in the document can have the following types of headers and footers:
 
 * First page: Used only on the first page of the section.
-* Even pages: Used on all even numbered pages in the section.
+* Even pages: Used on all even-numbered pages in the section.
 * Default: Used on all pages of the section, where the first or even pages are not applicable or not specified.
 
 You can define this by setting format properties of the corresponding section using the following sample code.
 
 ```typescript
-//Defines whether different header footer is required for first page of the section
+//Defines whether a different header/footer is required for the first page of the section
 documenteditor.selection.sectionFormat.differentFirstPage= true;
-//Defines whether different header footer is required for odd and even pages in the section
+//Defines whether different header/footer is required for odd and even pages in the section
 documenteditor.selection.sectionFormat.differentOddAndEvenPages= true;
 ```
 
 ## Go to header footer region
 
-Double click in header or footer region to move the selection into it.
+Double-click in the header or footer region to move the selection into it.
 
 ```typescript
 documenteditor.selection.goToHeader();
@@ -39,47 +39,47 @@ documenteditor.selection.goToFooter();
 
 ## Link to previous
 
-Link to previous is enabled by default when document has more than one section. If you're using different headers and footers such as different first page or different odd and even pages, they can't be linked together because they're all separate.
+Link to previous is enabled by default when the document has more than one section. If you're using different headers and footers such as a different first page or different odd and even pages, they can't be linked together because they're all separate.
 
-Before setting or getting the link to previous value, use the ['goToHeader'](https://ej2.syncfusion.com/aspnetmvc/documentation/api/document-editor/selection#gotoheader) or ['goToFooter'](https://ej2.syncfusion.com/aspnetmvc/documentation/api/document-editor/selection#gotofooter) API to move the current selection to the header or footer region.
+Before setting or getting the link to previous value, use the [`goToHeader`](https://ej2.syncfusion.com/aspnetmvc/documentation/api/document-editor/selection#gotoheader) or [`goToFooter`](https://ej2.syncfusion.com/aspnetmvc/documentation/api/document-editor/selection#gotofooter) API to move the current selection to the header or footer region.
 
-You can get or set the default header footer link to previous value of a section at cursor position by using the following sample code.
+You can get or set the default header footer link to previous value of a section at the cursor position by using the following sample code.
 
 ```typescript
 container.documentEditor.selection.sectionFormat.oddPageHeader.linkToPrevious = false;
 container.documentEditor.selection.sectionFormat.oddPageFooter.linkToPrevious = false;
 ```
 
-In case the document has different header and footer types, such as different first page, odd, and even pages.
+In case the document has different header and footer types, such as different first page, odd, and even pages, use the following sample code.
 
 ```typescript
 // Different first page
 container.documentEditor.selection.sectionFormat.firstPageHeader.linkToPrevious = false;
 container.documentEditor.selection.sectionFormat.firstPageFooter.linkToPrevious = false;
 //Even page
-container.documentEditor.selection.sectionFormat.firstPageHeader.linkToPrevious = false;
-container.documentEditor.selection.sectionFormat.firstPageFooter.linkToPrevious = false;
+container.documentEditor.selection.sectionFormat.evenPageHeader.linkToPrevious = false;
+container.documentEditor.selection.sectionFormat.evenPageFooter.linkToPrevious = false;
 ```
 
-N> When there is more than one section in the document, the Link to Previous option becomes available. By default, this feature is disabled state in UI and set to return false for the first section.
+N> When there is more than one section in the document, the Link to Previous option becomes available. By default, this feature is disabled in the UI and set to return false for the first section.
 
 ## Header and footer distance
 
-You can define the distance of header region content from the top of the page.
+You can define the distance of the header region content from the top of the page.
 
 ```typescript
 documenteditor.selection.sectionFormat.headerDistance= 36;
 ```
 
-Same way, you can define the distance of footer region content from the bottom of the page.
+In the same way, you can define the distance of the footer region content from the bottom of the page.
 
 ```typescript
-documenteditor.selection.sectionFormat.footerDistace=36;
+documenteditor.selection.sectionFormat.footerDistance=36;
 ```
 
 ## Close header footer region
 
-Move the selection to the document body from header or footer region by double clicking or tapping the document area.
+Move the selection to the document body from the header or footer region by double-clicking or tapping the document area.
 
 ```typescript
 documenteditor.selection.closeHeaderFooter()
@@ -87,7 +87,7 @@ documenteditor.selection.closeHeaderFooter()
 
 ## Online Demo
 
-Explore how to add and customize headers and footers in Word documents using the ASP.NET MVC Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/headersandfooters#/tailwind3).
+Explore how to add and customize headers and footers in Word documents using the ASP.NET MVC DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/headersandfooters#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Headers and Footers in ASP.NET MVC DOCX Editor
+# Headers and Footers in ASP.NET MVC Document Editor
 
 The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor)  supports headers and footers in its documents. Each section in the document can have the following types of headers and footers:
 
@@ -87,7 +87,7 @@ documenteditor.selection.closeHeaderFooter()
 
 ## Online Demo
 
-Explore how to add and customize headers and footers in Word documents using the ASP.NET MVC DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/headersandfooters#/tailwind3).
+Explore how to add and customize headers and footers in Word documents using the ASP.NET MVC Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-mvc/documenteditor/headersandfooters#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Headers and Footers
+# Headers and Footers in ASP.NET MVC DOCX Editor
 
 The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor)  supports headers and footers in its documents. Each section in the document can have the following types of headers and footers:
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/header-footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Header Footer in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about Header Footer in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Header Footer in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Header Footer
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: History in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about history in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about history in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: History
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: History in ASP.NET MVC Document Editor Component
-description: Learn here all about history in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: History in ASP.NET MVC DOCX Editor Component | Synfusion
+description: Learn here all about history in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: History
 documentation: ug
@@ -10,7 +10,7 @@ documentation: ug
 
 # History
 
-Document editor tracks the history of all editing actions done in the document, which allows undo and redo functionality.
+The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) tracks the history of all editing actions done in the document, which allows undo and redo functionality.
 
 ## Enable or disable history
 
@@ -23,12 +23,13 @@ Inject the `EditorHistory` module in your application to provide history preserv
 {% include code-snippet/document-editor/asp-net-mvc/history/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="History.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 
-You can enable or disable history preservation for a document editor instance any time using the `enableEditorHistory` property.
+You can enable or disable history preservation for a DOCX Editor instance at any time using the `enableEditorHistory` property.
 
 ```typescript
 editor.enableEditorHistory = false;
@@ -36,7 +37,7 @@ editor.enableEditorHistory = false;
 
 ## Undo and redo
 
-You can perform undo and redo by `CTRL+Z` and `CTRL+Y` keyboard shortcuts. Document editor exposes API to do it programmatically. To undo the last editing operation in document editor, refer to the following sample code.
+You can perform undo and redo by using the `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts. The DOCX Editor exposes APIs to do it programmatically. To undo the last editing operation in the DOCX Editor, refer to the following sample code.
 
 ```typescript
 editor.editorHistory.undo();
@@ -50,7 +51,7 @@ editor.editorHistory.redo();
 
 ## Stack size
 
-History of editing actions will be maintained in stack, so that the last item will be reverted first. By default, document editor limits the size of undo and redo stacks to 500 each respectively. However, you can customize this limit.
+The history of editing actions will be maintained in a stack, so that the last item will be reverted first. By default, the DOCX Editor limits the size of the undo and redo stacks to 500 each, respectively. However, you can customize this limit.
 
 ```typescript
 editor.editorHistory.undoLimit = 400;

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: History in ASP.NET MVC DOCX Editor Component | Synfusion
+title: History in ASP.NET MVC DOCX Editor Component | Syncfusion
 description: Learn here all about history in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: History
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# History
+# History in ASP.NET MVC DOCX Editor
 
 The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) tracks the history of all editing actions done in the document, which allows undo and redo functionality.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/history.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# History in ASP.NET MVC DOCX Editor
+# History in ASP.NET MVC Document Editor
 
 The [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) tracks the history of all editing actions done in the document, which allows undo and redo functionality.
 
@@ -29,7 +29,7 @@ Inject the `EditorHistory` module in your application to provide history preserv
 
 
 
-You can enable or disable history preservation for a DOCX Editor instance at any time using the `enableEditorHistory` property.
+You can enable or disable history preservation for a Document Editor instance at any time using the `enableEditorHistory` property.
 
 ```typescript
 editor.enableEditorHistory = false;
@@ -37,7 +37,7 @@ editor.enableEditorHistory = false;
 
 ## Undo and redo
 
-You can perform undo and redo by using the `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts. The DOCX Editor exposes APIs to do it programmatically. To undo the last editing operation in the DOCX Editor, refer to the following sample code.
+You can perform undo and redo by using the `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts. The Document Editor exposes APIs to do it programmatically. To undo the last editing operation in the Document Editor, refer to the following sample code.
 
 ```typescript
 editor.editorHistory.undo();
@@ -51,7 +51,7 @@ editor.editorHistory.redo();
 
 ## Stack size
 
-The history of editing actions will be maintained in a stack, so that the last item will be reverted first. By default, the DOCX Editor limits the size of the undo and redo stacks to 500 each, respectively. However, you can customize this limit.
+The history of editing actions will be maintained in a stack, so that the last item will be reverted first. By default, the Document Editor limits the size of the undo and redo stacks to 500 each, respectively. However, you can customize this limit.
 
 ```typescript
 editor.editorHistory.undoLimit = 400;


### PR DESCRIPTION
Addressing the ASP.NET MVC DOCX Editor ug documentation issue

Getting Started:

<img width="727" height="285" alt="image" src="https://github.com/user-attachments/assets/7f601b12-36fe-4651-9df6-41a5dbe114df" />

Global and Local
<img width="714" height="259" alt="image" src="https://github.com/user-attachments/assets/34ee6f4e-5ed9-451e-a062-0d1232e6534c" />

Header Footer
<img width="718" height="270" alt="image" src="https://github.com/user-attachments/assets/a2c1ef66-15e2-4e67-a21b-bd421f84c75f" />

History
<img width="719" height="270" alt="image" src="https://github.com/user-attachments/assets/087bd69c-1a49-40db-a318-ecce94497ece" />


