### PR TITLE
Task(1046055): Addressing ASP.NET MVC DOCX Editor ug documentation

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Set Default Format In Document Editor in ASP.NET MVC Document Editor Component
-description: Learn here all about how to set default format in Document Editor in Syncfusion ASP.NET MVC Document Editor component of syncfusion and more.
+title: Set the Default Format in Syncfusion ASP.NET MVC DOCX Editor Component
+description: Learn here all about how to set the default character, paragraph, and section format in the Syncfusion ASP.NET MVC DOCX Editor component
 platform: document-processing
-control: Set Default Format In Document Editor
+control: Set Default Format in the Document Editor
 documentation: ug
 ---
 
 
-# How to set the default character, paragraph and section format in Document Editor component
+# Set Default Format in the ASP.NET MVC DOCX Editor Component
 
-You can set the default character format, paragraph format and section format in Document editor.
+You can set the default character format, paragraph format, and section format in the Document Editor.
 
 ## Set the default character format
 
-You can use `setDefaultCharacterFormat` method to set the default character format. For example, Document editor default font size is 11 and you can change it as any valid value.
+You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the default font size of the DOCX Editor is `11`, and you can change it to any valid value.
 
 
 {% tabs %}
@@ -22,11 +22,12 @@ You can use `setDefaultCharacterFormat` method to set the default character form
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/character-format-font/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Character-format-font.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
-Similarly, you can change the required `CharacterFormatProperties` default value.
+Similarly, you can change the required `CharacterFormatProperties` default values.
 
 
 {% tabs %}
@@ -34,13 +35,14 @@ Similarly, you can change the required `CharacterFormatProperties` default value
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/character-format/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Character-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 ## Set the default paragraph format
 
-You can use `setDefaultParagraphFormat` API to set the default paragraph format. You can change the required `ParagraphFormatProperties` default value.
+You can use the `setDefaultParagraphFormat` API to set the default paragraph format. You can change the required `ParagraphFormatProperties` default values.
 
 
 {% tabs %}
@@ -48,13 +50,14 @@ You can use `setDefaultParagraphFormat` API to set the default paragraph format.
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/paragraph-format/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Paragraph-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 ## Set the default section format
 
-You can use `setDefaultSectionFormat` API to set the default section format. You can change the required `SectionFormatProperties` default value.
+You can use the `setDefaultSectionFormat` API to set the default section format. You can change the required `SectionFormatProperties` default values.
 
 
 {% tabs %}
@@ -62,5 +65,6 @@ You can use `setDefaultSectionFormat` API to set the default section format. You
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/section-format/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Section-format.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
@@ -8,13 +8,13 @@ documentation: ug
 ---
 
 
-# Set Default Format in the ASP.NET MVC DOCX Editor Component
+# Set Default Format in the ASP.NET MVC Document Editor Component
 
 You can set the default character format, paragraph format, and section format in the Document Editor.
 
 ## Set the default character format
 
-You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the default font size of the DOCX Editor is `11`, and you can change it to any valid value.
+You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the default font size of the Document Editor is `11`, and you can change it to any valid value.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Set Default Format in the ASP.NET MVC Document Editor Component
+# Set Default Format in the ASP.NET MVC Document Editor component
 
 You can set the default character format, paragraph format, and section format in the Document Editor.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/set-default-format-in-document-editor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Set the Default Format in Syncfusion ASP.NET MVC DOCX Editor Component
-description: Learn here all about how to set the default character, paragraph, and section format in the Syncfusion ASP.NET MVC DOCX Editor component
+description: Learn here all about how to set the default character, paragraph, and section format in the Syncfusion ASP.NET MVC Document Editor component
 platform: document-processing
 control: Set Default Format in the Document Editor
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Show or Hide a Spinner in Syncfusion ASP.NET MVC DOCX Editor Component
+title: Show or Hide a Spinner in ASP.NET MVC DOCX Editor | Syncfusion
 description: Learn here all about how to show or hide a spinner while opening a document in the Syncfusion ASP.NET MVC DOCX Editor component
 platform: document-processing
 control: Show or Hide a Spinner
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# How to Show and Hide the Spinner in Syncfusion ASP.NET MVC DOCX Editor
+# How to Show and Hide the Spinner in ASP.NET MVC DOCX Editor
 
 Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide the spinner while opening a document in the DOCX Editor.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: Show Hide Spinner in ASP.NET MVC Document Editor Component
-description: Learn here all about how to show hide spinner in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Show or Hide a Spinner in Syncfusion ASP.NET MVC DOCX Editor Component
+description: Learn here all about how to show or hide a spinner while opening a document in the Syncfusion ASP.NET MVC DOCX Editor component
 platform: document-processing
-control: Show Hide Spinner
+control: Show or Hide a Spinner
 documentation: ug
 ---
 
 
-# How to show and hide spinner while opening document in React Document Editor component
+# How to Show and Hide the Spinner in Syncfusion ASP.NET MVC DOCX Editor
 
-Using [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide spinner while opening document in DocumentEditor.
+Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide the spinner while opening a document in the DOCX Editor.
 
 ```typescript
-// showSpinner() will make the spinner visible
+// showSpinner() makes the spinner visible
 showSpinner(document.getElementById('container'));
 
-// hideSpinner() method used hide spinner
+// hideSpinner() hides the spinner
 hideSpinner(document.getElementById('container'));
 ```
 
@@ -26,8 +26,8 @@ hideSpinner(document.getElementById('container'));
 {% include code-snippet/document-editor/asp-net-mvc/document-editor-container/spinner/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Spinner.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-
-N> In above example, we have used setInterval to hide spinner, just for demo purpose.
+N> In the above example, `setInterval` is used to hide the spinner for demo purposes only.

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Show or Hide a Spinner in ASP.NET MVC DOCX Editor | Syncfusion
-description: Learn here all about how to show or hide a spinner while opening a document in the Syncfusion ASP.NET MVC DOCX Editor component
+description: Learn here all about how to show or hide a spinner while opening a document in the Syncfusion ASP.NET MVC Document Editor component
 platform: document-processing
 control: Show or Hide a Spinner
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/how-to/show-hide-spinner.md
@@ -8,9 +8,9 @@ documentation: ug
 ---
 
 
-# How to Show and Hide the Spinner in ASP.NET MVC DOCX Editor
+# How to Show and Hide the Spinner in ASP.NET MVC Document Editor
 
-Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core/) component, you can show or hide the spinner while opening a document in the DOCX Editor.
+Using the [`spinner`](https://ej2.syncfusion.com/aspnetcore/documentation/spinner/getting-started-asp-core) component, you can show or hide the spinner while opening a document in the Document Editor.
 
 ```typescript
 // showSpinner() makes the spinner visible

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: Image in ASP.NET MVC Document Editor Component
-description: Learn here all about image in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Image in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about image in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Image
 documentation: ug
 ---
 
 
-# Images
+# Images in ASP.NET MVC DOCX Editor
 
-Document Editor supports common raster format images like PNG, BMP, JPEG, SVG and GIF. You can insert an image file or online image in the document using the `insertImage()` method.
+[ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) supports common raster format images like PNG, BMP, JPEG, SVG, and GIF. You can insert an image file or an online image in the document using the `insertImage()` method.
 
 
 
@@ -19,29 +19,30 @@ Document Editor supports common raster format images like PNG, BMP, JPEG, SVG an
 {% include code-snippet/document-editor/asp-net-mvc/image/razor %}
 {% endhighlight %}
 {% highlight c# tabtitle="Image.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 
-Image files will be internally converted to base64 string. Whereas, online images are preserved as URL.
+Image files will be internally converted to a base64 string. Whereas, online images are preserved as URLs.
 
 ## Image resizing
 
-Document editor provides built-in image resizer that can be injected into your application based on the requirements. This allows to resize the image by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
+Document Editor provides a built-in image resizer that can be injected into your application based on the requirements. This allows you to resize the image by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
 
 ![Image](images/image.JPG)
 
 ## Changing size
 
-Document editor exposes API to get or set the size of the selected image.
+Document Editor exposes an API to get or set the size of the selected image.
 
 ```typescript
 documenteditor.selection.imageFormat.width = 800;
 documenteditor.selection.imageFormat.height = 800;
 ```
 
-N> Images are stored and processed (read/write) as base64 string in DocumentEditor. The online image URL is preserved as a URL in DocumentEditor upon saving.
+N> Images are stored and processed (read/write) as a base64 string in DocumentEditor. The online image URL is preserved as a URL in DocumentEditor upon saving.
 
 ## Text wrapping style
 
@@ -49,7 +50,7 @@ Text wrapping refers to how images fit with surrounding text in a document. [Ref
 
 ## Positioning the image
 
-DocumentEditor preserves the position properties of the image and displays the image based on position properties. It does not support modifying the position properties. Whereas the image will be automatically moved along with text edited if it is positioned relative to the line or paragraph.
+Document Editor preserves the position properties of the image and displays the image based on position properties. It does not support modifying the position properties. Whereas, the image will be automatically moved when the text is edited if it is positioned relative to the line or paragraph.
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
@@ -1,14 +1,14 @@
 ---
 layout: post
 title: Image in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about image in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about image in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Image
 documentation: ug
 ---
 
 
-# Images in ASP.NET MVC Document Editor
+# Images in ASP.NET MVC Document Editor component
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) supports common raster format images like PNG, BMP, JPEG, SVG, and GIF. You can insert an image file or an online image in the document using the `insertImage()` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/image.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Images in ASP.NET MVC DOCX Editor
+# Images in ASP.NET MVC Document Editor
 
 [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor) supports common raster format images like PNG, BMP, JPEG, SVG, and GIF. You can insert an image file or an online image in the document using the `insertImage()` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: Import in ASP.NET MVC Document Editor Component | Syncfusion
-description: Learn here all about Import in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Import in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about Import in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Import
 documentation: ug
 ---
 
 
-# Importing in the ASP.NET MVC Document Editor Component
+# Importing in the ASP.NET MVC DOCX Editor Component
 
-In Document Editor, the documents are stored in its own format called **Syncfusion Document Text (SFDT)**.
+In [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor), documents are stored in its own format called **Syncfusion Document Text (SFDT)**.
 
 The following example shows how to open SFDT data in Document Editor.
 
@@ -28,9 +28,9 @@ The following example shows how to open SFDT data in Document Editor.
 
 
 
-## Import document from local machine
+## Import a document from a local machine
 
-The following example shows how to import document from local machine.
+The following example shows how to import a document from a local machine.
 
 
 
@@ -46,9 +46,9 @@ The following example shows how to import document from local machine.
 
 
 
-## Convert word documents into SFDT
+## Convert Word documents into SFDT
 
-You can convert word documents into SFDT format using the [`Syncfusion.EJ2.WordEditor.AspNet.MVC5`](<https://www.nuget.org/packages/Syncfusion.EJ2.WordEditor.AspNet.MVC5/>) by the web API service implementation. This library helps you to convert word documents (.dotx,.docx,.docm,.dot,.doc), rich text format documents (.rtf), and text documents (.txt) into SFDT format. Refer to the following example.
+You can convert Word documents into SFDT format using the [`Syncfusion.EJ2.WordEditor.AspNet.MVC5`](<https://www.nuget.org/packages/Syncfusion.EJ2.WordEditor.AspNet.MVC5/>) by the web API service implementation. This library helps you to convert Word documents (.dotx, .docx, .docm, .dot, .doc), rich text format documents (.rtf), and text documents (.txt) into SFDT format. Refer to the following example.
 
 
 
@@ -64,7 +64,7 @@ You can convert word documents into SFDT format using the [`Syncfusion.EJ2.WordE
 
 
 
-Here’s how to handle the server-side action for converting word document in to SFDT.
+Here's how to handle the server-side action for converting a Word document into SFDT.
 
 ```csharp
 [HttpPost]

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Importing in the ASP.NET MVC DOCX Editor Component
+# Importing in the ASP.NET MVC Document Editor Component
 
 In [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor), documents are stored in its own format called **Syncfusion Document Text (SFDT)**.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/import.md
@@ -1,14 +1,14 @@
 ---
 layout: post
 title: Import in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about Import in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about Import in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Import
 documentation: ug
 ---
 
 
-# Importing in the ASP.NET MVC Document Editor Component
+# Importing in the ASP.NET MVC Document Editor component
 
 In [ASP.NET MVC DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-mvc-docx-editor) (Document Editor), documents are stored in its own format called **Syncfusion Document Text (SFDT)**.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Keyboard Shortcuts in Document Editor Component
+# Keyboard Shortcuts in ASP.NET MVC Document Editor component
 
 ## Text formatting
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
@@ -8,11 +8,11 @@ documentation: ug
 ---
 
 
-# Keyboard Shortcuts in DOCX Editor Component
+# Keyboard Shortcuts in Document Editor Component
 
 ## Text formatting
 
-The following table lists the default keyboard shortcuts in the DOCX Editor for formatting text:
+The following table lists the default keyboard shortcuts in the Document Editor for formatting text:
 
 | Key combination | Description |
 |-----------------|-------------|

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
@@ -1,18 +1,18 @@
 ---
 layout: post
-title: Keyboard Shortcut in ASP.NET MVC Document Editor Component | Syncfusion
-description: Learn here all about keyboard shortcut in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
+title: Keyboard Shortcut in ASP.NET MVC DOCX Editor Component | Syncfusion
+description: Learn here all about keyboard shortcut in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Keyboard Shortcut
 documentation: ug
 ---
 
 
-# Keyboard Shortcuts in Document Editor Component
+# Keyboard Shortcuts in DOCX Editor Component
 
 ## Text formatting
 
-The following table lists the default keyboard shortcuts in document editor for formatting text:
+The following table lists the default keyboard shortcuts in the DOCX Editor for formatting text:
 
 | Key combination | Description |
 |-----------------|-------------|
@@ -26,7 +26,7 @@ The following table lists the default keyboard shortcuts in document editor for 
 
 ## Paragraph formatting
 
-The following table lists the default keyboard shortcuts for formatting the paragraph:
+The following table lists the default keyboard shortcuts for formatting a paragraph:
 
 | Key combination | Description |
 |-----------------|-------------|
@@ -40,7 +40,7 @@ The following table lists the default keyboard shortcuts for formatting the para
 |Ctrl + 0 | No spacing is applied before the selected paragraphs.|
 |Ctrl + M | Increases the left indent of selected paragraphs by a factor of 36 points.|
 |Ctrl + Shift + M | Decreases the left indent of selected paragraphs by a factor of 36 points.|
-|Ctrl + * | Show/Hide the hidden characters like spaces, tab, paragraph marks, and breaks.|
+|Ctrl + * | Shows or hides the hidden characters like spaces, tab, paragraph marks, and breaks.|
 
 ## Clipboard
 
@@ -50,7 +50,7 @@ The following table lists the default keyboard shortcuts for formatting the para
 |Ctrl + V | Pastes plain text content from the clipboard.|
 |Ctrl + X | Moves selected content to the clipboard.|
 
-## Keyboard shortcut to navigate around the document
+## Keyboard shortcuts to navigate around the document
 
 |Key Combination| Description |
 |---------------|-------------|
@@ -71,7 +71,7 @@ The following table lists the default keyboard shortcuts for formatting the para
 |Ctrl + Home| Moves the cursor position to the start of a document.|
 |Ctrl + End| Moves the cursor position to the end of a document.|
 
-## Keyboard shortcut to extend selection
+## Keyboard shortcuts to extend selection
 
 |Key Combination| Description|
 |---------------|------------|
@@ -80,7 +80,7 @@ The following table lists the default keyboard shortcuts for formatting the para
 |Shift + Down arrow| Extends selection one line downward.|
 |Shift + Up arrow| Extends selection one line upward.|
 |Shift + Home| Extends selection to the start of a line.|
-|Shift + End| Extends Selection to the end of a line.|
+|Shift + End| Extends selection to the end of a line.|
 |Ctrl + A| Extends selection to the entire document.|
 |Ctrl + Shift + Left arrow| Extends selection one word to the left.|
 |Ctrl + Shift + Right arrow| Extends selection one word to the right.|
@@ -93,40 +93,40 @@ The following table lists the default keyboard shortcuts for formatting the para
 
 |Key Combination|Description|
 |---------------|-----------|
-|Ctrl + F| Opens options pane.|
-|Ctrl + H| Opens replace tab in options pane.|
+|Ctrl + F| Opens the options pane.|
+|Ctrl + H| Opens the replace tab in the options pane.|
 
-## Create, Save and Print document
+## Create, save, and print a document
 
 |Key Combination|Description|
 |---------------|-----------|
-|Ctrl + N| Opens empty document.|
+|Ctrl + N| Opens an empty document.|
 |Ctrl + S| Saves the document in SFDT format.|
 |Ctrl + P| Prints the document.|
 
-## Edit Operation
+## Edit operations
 
 |Key Combination|Description|
 |---------------|-----------|
 |Backspace | Deletes one character to the left.|
 |Delete | Deletes one character to the right.|
-|Ctrl + Z | Undo last performed action.|
-|Ctrl + Y | Redo last undo action.|
+|Ctrl + Z | Undoes the last performed action.|
+|Ctrl + Y | Redoes the last undo action.|
 
 ## Insert special characters
 
 |Key Combination|Description|
 |---------------|-----------|
-|Ctrl + Enter | Inserts page break.|
-|Shift + Enter | Inserts line break.|
+|Ctrl + Enter | Inserts a page break.|
+|Shift + Enter | Inserts a line break.|
 
 ## Dialog
 
 |Key Combination|Description|
 |---------------|-----------|
-|Ctrl + F| Opens options pane.|
-|Ctrl + D| Opens font dialog.|
-|Ctrl + K| Opens hyperlink dialog.|
+|Ctrl + F| Opens the options pane.|
+|Ctrl + D| Opens the font dialog.|
+|Ctrl + K| Opens the hyperlink dialog.|
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/keyboard-shortcut.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Keyboard Shortcut in ASP.NET MVC DOCX Editor Component | Syncfusion
-description: Learn here all about keyboard shortcut in Syncfusion ASP.NET MVC DOCX Editor component of Syncfusion Essential JS 2 and more.
+description: Learn here all about keyboard shortcut in Syncfusion ASP.NET MVC Document Editor component of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Keyboard Shortcut
 documentation: ug


### PR DESCRIPTION
Addressing ASP.NET MVC DOCX Editor ug documentation

How To ==> Set default formats
<img width="741" height="270" alt="image" src="https://github.com/user-attachments/assets/f0162814-acfa-4351-9981-6799ea4e1377" />

How To ==> Show or Hide Snipper
<img width="747" height="273" alt="image" src="https://github.com/user-attachments/assets/95e40d25-1d3e-450c-a0b7-531ddec3658a" />

Images
<img width="726" height="265" alt="image" src="https://github.com/user-attachments/assets/a28e5731-b8d9-46ec-9fa8-3ddc08416136" />

import
<img width="734" height="277" alt="image" src="https://github.com/user-attachments/assets/0475a5ef-982c-4e40-8dfd-57d9c95452c1" />

Keyboard shortcuts
<img width="733" height="277" alt="image" src="https://github.com/user-attachments/assets/62ce97ca-50f3-446c-a024-e8230867dd66" />



