### PR TITLE
Task(1046246): Addressing ASP.NET MVC DOCX Editor ug documentation page issues

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
@@ -67,7 +67,7 @@ public DocumentEditorController(IWebHostEnvironment hostingEnvironment, IMemoryC
 
 public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string> jsonObject)
 {
-    if (jsonObject == null && !jsonObject.ContainsKey("documentName"))
+    if (jsonObject == null || !jsonObject.ContainsKey("documentName"))
     {
       return null;
     }

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open Box Cloud Files in ASP.NET MVC Document Editor | Syncfusion
-description: Learn here to open a document from Box cloud file storage in Syncfusion ASP.NET MVC Document editor control of Syncfusion Essential JS 2 and more.
+title: Open Box Cloud Files in ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn here to open a document from Box cloud file storage in Syncfusion ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more.
 platform: document-processing
 control: Opening from Box cloud file storage
 documentation: ug
@@ -10,7 +10,7 @@ domainurl: ##DomainURL##
 
 # Open document from Box cloud file storage in ASP.NET MVC
 
-To load a document from Box cloud file storage in a document Editor, you can follow the steps below
+To load a document from Box cloud file storage in a Document Editor, you can follow the steps below.
 
 **Step 1:** Set up a Box developer account and create a Box application
 
@@ -35,7 +35,7 @@ using Box.V2.Config;
 using Box.V2.Models;
 ```
 
-* Add the following private fields and constructor parameters to the `DocumentEditorController` class, In the constructor, assign the values from the configuration to the corresponding fields
+* Add the following private fields and constructor parameters to the `DocumentEditorController` class. In the constructor, assign the values from the configuration to the corresponding fields.
 
 ```csharp
 private IConfiguration _configuration;
@@ -69,7 +69,7 @@ public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string>
 {
     if (jsonObject == null && !jsonObject.ContainsKey("documentName"))
     {
-      return null
+      return null;
     }
     MemoryStream stream = new MemoryStream();
     // Initialize the Box API client with your authentication credentials
@@ -81,8 +81,9 @@ public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string>
     var items = await client.FoldersManager.GetFolderItemsAsync(_folderID, 1000, autoPaginate: true);
     var files = items.Entries.Where(i => i.Type == "file");
 
-    // Filter the files based on the objectName
-    var matchingFile = files.FirstOrDefault(file => file.Name == objectName);
+    // Filter the files based on the documentName
+    var documentName = jsonObject["documentName"];
+    var matchingFile = files.FirstOrDefault(file => file.Name == documentName);
 
     // Fetch the file from Box storage by its name
     var fileStream = await client.FilesManager.DownloadAsync(matchingFile.Id);
@@ -118,11 +119,11 @@ public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string>
 }
 ```
 
-N> replace **Your_Box_Storage_Access_Token** with your actual box access token, and **Your_Folder_ID** with the ID of the folder in your box storage where you want to perform specific operations. Remember to use your valid box API credentials, as **Your_Box_Storage_ClientID** and **Your_Box_Storage_ClientSecret"** are placeholders for your application's API key and secret.
+N> Replace **Your_Box_Storage_Access_Token** with your actual Box access token, and **Your_Folder_ID** with the ID of the folder in your Box storage where you want to perform specific operations. Remember to use your valid Box API credentials, as **Your_Box_Storage_ClientID** and **Your_Box_Storage_ClientSecret** are placeholders for your application's API key and secret.
 
 **Step 4:**  Modify the Index.cshtml File in the Document Editor sample
 
-In the client-side, the document is returned from the web service is opening using `open` method.
+In the client-side, the document returned from the web service is opened using the `open` method.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/box-cloud-file-storage.md
@@ -81,9 +81,8 @@ public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string>
     var items = await client.FoldersManager.GetFolderItemsAsync(_folderID, 1000, autoPaginate: true);
     var files = items.Entries.Where(i => i.Type == "file");
 
-    // Filter the files based on the documentName
-    var documentName = jsonObject["documentName"];
-    var matchingFile = files.FirstOrDefault(file => file.Name == documentName);
+    // Filter the files based on the objectName
+    var matchingFile = files.FirstOrDefault(file => file.Name == objectName);
 
     // Fetch the file from Box storage by its name
     var fileStream = await client.FilesManager.DownloadAsync(matchingFile.Id);

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/dropbox-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/dropbox-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open Dropbox Files in ASP.NET MVC Document Editor | Syncfusion
-description: Learn about how to Open document from Dropbox cloud file storage in ASP.NET MVC Document editor control of Syncfusion Essential JS 2 and more details.
+title: Open Dropbox Files in ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn about how to open a document from Dropbox cloud file storage in ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more details.
 platform: document-processing
 control: Open document from Dropbox cloud file storage
 documentation: ug
@@ -10,7 +10,7 @@ domainurl: ##DomainURL##
 
 # Open document from Dropbox cloud file storage in ASP.NET MVC
 
-To load a document from Dropbox cloud file storage in a Document editor, you can follow the steps below
+To load a document from Dropbox cloud file storage in a Document Editor, you can follow the steps below.
 
 **Step 1:** Create a Dropbox API
 
@@ -34,7 +34,7 @@ using Dropbox.Api;
 using Dropbox.Api.Files;
 ```
 
-* Add the following private fields and constructor parameters to the `DocumentEditorController` class, In the constructor, assign the values from the configuration to the corresponding fields
+* Add the following private fields and constructor parameters to the `DocumentEditorController` class. In the constructor, assign the values from the configuration to the corresponding fields.
 
 ```csharp
 private IConfiguration _configuration;
@@ -58,14 +58,14 @@ public DocumentEditorController(IWebHostEnvironment hostingEnvironment, IMemoryC
 [AcceptVerbs("Post")]
 [HttpPost]
 [EnableCors("AllowAllOrigins")]
-[Route("LoadFromBoxCloud")]
+[Route("LoadFromDropBox")]
 //Post action for Loading the documents
 
 public async Task<string> LoadFromDropBox([FromBody] Dictionary<string, string> jsonObject)
 {
     if (jsonObject == null && !jsonObject.ContainsKey("documentName"))
     {
-      return null
+      return null;
     }
     MemoryStream stream = new MemoryStream();
         
@@ -105,7 +105,7 @@ N> Replace **Your_Dropbox_Access_Token** with your actual Dropbox access token a
 
 **Step 4:**  Modify the Index.cshtml File in the Document Editor sample
 
-In the client-side, the document is returned from the web service is opening using `open` method.
+In the client-side, the document returned from the web service is opened using the `open` method.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/dropbox-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/dropbox-cloud-file-storage.md
@@ -63,7 +63,7 @@ public DocumentEditorController(IWebHostEnvironment hostingEnvironment, IMemoryC
 
 public async Task<string> LoadFromDropBox([FromBody] Dictionary<string, string> jsonObject)
 {
-    if (jsonObject == null && !jsonObject.ContainsKey("documentName"))
+    if (jsonObject == null || !jsonObject.ContainsKey("documentName"))
     {
       return null;
     }

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/google-cloud-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/google-cloud-storage.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: Open Google Cloud Files in ASP.NET MVC Document Editor | Syncfusion
-description: Learn about how to Open document from Google Cloud Storage in ASP.NET MVC Document editor control of Syncfusion Essential JS 2 and more details.
+title: Open Google Cloud Files in ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn about how to open a document from Google Cloud Storage in ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more details.
 platform: document-processing
 control: Open document from Google Cloud Storage
 documentation: ug
 domainurl: ##DomainURL##
 ---
 
-# Open document from Google Cloud Storage in ASP.NET MVC Document editor
+# Open Google Cloud Storage documents in ASP.NET MVC Document Editor
 
-To load a document from Google Cloud Storage in a Document editor, you can follow the steps below
+To load a document from Google Cloud Storage in a Document Editor, you can follow the steps below.
 
 
 **Step 1:** Create a Simple Document Editor Sample in ASP.NET MVC
@@ -30,7 +30,7 @@ using Google.Cloud.Storage.V1;
 using Google.Apis.Auth.OAuth2;
 ```
 
-* Add the following private fields and constructor parameters to the `DocumentEditorController` class, In the constructor, assign the values from the configuration to the corresponding fields
+* Add the following private fields and constructor parameters to the `DocumentEditorController` class. In the constructor, assign the values from the configuration to the corresponding fields.
 
 ```csharp
 // Private readonly object _storageClient
@@ -71,14 +71,14 @@ public DocumentEditorController(IWebHostEnvironment hostingEnvironment, IMemoryC
 
 public async Task<string> LoadFromGoogleCloud([FromBody] Dictionary<string, string> jsonObject)
 {
-    if (jsonObject == null && !jsonObject.ContainsKey("documentName"))
+    if (jsonObject == null || !jsonObject.ContainsKey("documentName"))
     {
-      return null
+      return null;
     }
     MemoryStream stream = new MemoryStream();
 
     string bucketName = _bucketName;
-    string objectName = jsonObject["document"];
+    string objectName = jsonObject["documentName"];
     _storageClient.DownloadObject(bucketName, objectName, stream);
     stream.Position = 0;
 
@@ -105,13 +105,13 @@ public async Task<string> LoadFromGoogleCloud([FromBody] Dictionary<string, stri
 }
 ```
 
-N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket
+N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket.
 
 N> Replace **path/to/service-account-key.json** with the actual file path to your service account key JSON file. Make sure to provide the correct path and filename.
 
 **Step 3:**  Modify the Index.cshtml File in the Document Editor sample
 
-In the client-side, the document is returned from the web service is opening using `open` method.
+In the client-side, the document returned from the web service is opened using the `open` method.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/google-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/google-drive.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: Open Google Drive Files in ASP.NET MVC Document Editor | Syncfusion
-description: Learn about how to Open document from Google Drive in ASP.NET MVC Document editor control of Syncfusion Essential JS 2 and more details.
+title: Open Google Drive Files in ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn about how to open a document from Google Drive in ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more details.
 platform: document-processing
 control: Open document from Google Drive
 documentation: ug
 domainurl: ##DomainURL##
 ---
 
-# Open document from Google Drive in ASP.NET MVC Document editor
+# Open document from Google Drive in ASP.NET MVC Document Editor
 
-To load a document from Google Drive in a Document editor, you can follow the steps below
+To load a document from Google Drive in a Document Editor, you can follow the steps below.
 
 **Step 1:** Set up Google Drive API
 
@@ -34,7 +34,7 @@ using Google.Apis.Drive.v3;
 using Google.Apis.Util.Store;
 ```
 
-* Add the following private fields and constructor parameters to the `DocumentEditorController` class, In the constructor, assign the values from the configuration to the corresponding fields
+* Add the following private fields and constructor parameters to the `DocumentEditorController` class. In the constructor, assign the values from the configuration to the corresponding fields.
 
 ```csharp
 private IConfiguration _configuration;
@@ -130,13 +130,13 @@ public async Task<string> LoadFromGoogleDrive([FromBody] Dictionary<string, stri
 }
 ```
 
-N> Replace **Your Google Drive Folder ID**, **Your Application name**, and **Your Path to the OAuth 2.0 Client IDs json file** with your actual Google drive folder ID , Your name for your application and the path for the JSON file.
+N> Replace **Your Google Drive Folder ID**, **Your Application name**, and **Your Path to the OAuth 2.0 Client IDs json file** with your actual Google Drive folder ID, your name for your application, and the path for the JSON file.
 
 N> The **FolderId** part is the unique identifier for the folder. For example, if your folder URL is: `https://drive.google.com/drive/folders/abc123xyz456`, then the folder ID is `abc123xyz456`.
 
 **Step 4:**  Modify the Index.cshtml File in the Document Editor sample
 
-In the client-side, the document is returned from the web service is opening using `open` method.
+In the client-side, the document returned from the web service is opened using the `open` method.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/one-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-mvc/opening-documents/one-drive.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: Open OneDrive Files in ASP.NET MVC Document editor | Syncfusion
-description: Learn about how to Open document from One Drive in ASP.NET MVC Document editor control of Syncfusion Essential JS 2 and more details.
+title: Open OneDrive Files in ASP.NET MVC DOCX Editor | Syncfusion
+description: Learn about how to open a document from OneDrive in ASP.NET MVC Document Editor control of Syncfusion Essential JS 2 and more details.
 platform: document-processing
-control: Open document from One Drive
+control: Open document from OneDrive
 documentation: ug
 domainurl: ##DomainURL##
 ---
 
-# Open document from One Drive in ASP.NET MVC Document editor
+# Open document from OneDrive in ASP.NET MVC Document Editor
 
-To load a document from One Drive in a Document editor, you can follow the steps below
+To load a document from OneDrive in a Document Editor, you can follow the steps below.
 
 **Step 1:** Create the Microsoft graph API.
 
@@ -35,7 +35,7 @@ using Microsoft.Identity.Client;
 using Helpers;
 ```
 
-* Add the following private fields and constructor parameters to the `DocumentEditorController` class, In the constructor, assign the values from the configuration to the corresponding fields
+* Add the following private fields and constructor parameters to the `DocumentEditorController` class. In the constructor, assign the values from the configuration to the corresponding fields.
 
 ```csharp
 private IConfiguration _configuration;
@@ -54,13 +54,13 @@ public DocumentEditorController(IWebHostEnvironment hostingEnvironment, IMemoryC
 }
 ```
 
-* Create the `LoadFromOneDrive()` method to load the document from One Drive.
+* Create the `LoadFromOneDrive()` method to load the document from OneDrive.
 
 ```csharp
 [AcceptVerbs("Post")]
 [HttpPost]
 [EnableCors("AllowAllOrigins")]
-[Route("LoadFromBoxCloud")]
+[Route("LoadFromOneDrive")]
 //Post action for Loading the documents
 
 public async Task<string> LoadFromOneDrive([FromBody] Dictionary<string, string> jsonObject)
@@ -123,7 +123,7 @@ public async Task<string> LoadFromOneDrive([FromBody] Dictionary<string, string>
   },
   "AllowedHosts": "*",
   "TenantId": "Your_Tenant_ID",
-  "applApplicationIdicationId": "Your_Application_ID",
+  "ApplicationId": "Your_Application_ID",
   "FolderName": "Your_Folder_Name_To_Access_The_Files_In_OneDrive"
 }
 
@@ -133,7 +133,7 @@ N> Replace **Your_Tenant_ID**, **Your_Application_ID**, and **Your_Folder_Name_T
 
 **Step 4:**  Modify the Index.cshtml File in the Document Editor sample
 
-In the client-side, the document is returned from the web service is opening using `open` method.
+In the client-side, the document returned from the web service is opened using the `open` method.
 
 
 {% tabs %}
@@ -145,11 +145,11 @@ In the client-side, the document is returned from the web service is opening usi
 {% endhighlight %}
 {% endtabs %}
 
-N> The following NuGet packages are required to use the previous code example
-* **Microsoft.Identity.Client**
-* **Microsoft.Graph**
-* **Microsoft.Extensions.Configuration**
-* **Microsoft.Extensions.Configuration.FileExtensions**
-* **Microsoft.Extensions.Configuration.Json**
+N> The following NuGet packages are required to use the previous code example.
+- **Microsoft.Identity.Client**
+- **Microsoft.Graph**
+- **Microsoft.Extensions.Configuration**
+- **Microsoft.Extensions.Configuration.FileExtensions**
+- **Microsoft.Extensions.Configuration.Json**
 
 You can install these packages using the NuGet Package Manager in Visual Studio or Visual Studio Code.


### PR DESCRIPTION
Addressing ASP.NET MVC DOCX Editor ug documentation page issues

Opening document ==> Box cloud file storage
<img width="706" height="282" alt="image" src="https://github.com/user-attachments/assets/e75be3ec-1db5-4d8e-85d8-6602be5d78c4" />

Opening document ==> Drop box cloud storage
<img width="626" height="272" alt="image" src="https://github.com/user-attachments/assets/9bde0695-a09a-4aad-84b5-044828a28fd4" />

Opening document ==> Google cloud storage
<img width="632" height="311" alt="image" src="https://github.com/user-attachments/assets/8cb44866-7ebc-40ea-a41c-c6345854bce1" />

Opening document ==> Google drive
<img width="626" height="306" alt="image" src="https://github.com/user-attachments/assets/afe13588-7dff-41f3-93e6-97c5dd12370d" />

Opening document ==> OneDrive
<img width="633" height="311" alt="image" src="https://github.com/user-attachments/assets/e60ad7ba-32b0-4bd7-8353-5e041552b0e4" />



