### PR TITLE
Task(1044664): Addressing ASP.NET Core DOCX Editor UG documentation pages

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/deploy-document-editor-component-for-mobile.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/deploy-document-editor-component-for-mobile.md
@@ -1,29 +1,24 @@
----
+﻿---
 layout: post
-title: Deploy Document Editor For Mobile in | Syncfusion
-description: Learn here all about deploy document editor component for mobile in Syncfusion Document Editor component of syncfusion and more.
+title: Deploy the DOCX Editor component for mobile | Syncfusion
+description: Learn here all about deploying the Document Editor component for mobile in the Syncfusion Document Editor component and more.
 platform: document-processing
-control: Deploy Document Editor Component For Mobile
+control: Deploy the Document Editor component for mobile
 documentation: ug
 ---
 
+# Deploy the Document Editor component for mobile
 
-# Deploy Document Editor component for Mobile
+## Document Editor component for mobile
 
-## Document editor component for Mobile
-
-At present, [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component is not responsive for mobile, and the editing functionalities aren't ensured in mobile browsers. Whereas it works properly as a document viewer in mobile browsers.
-
-Hence, it is recommended to switch the Document editor component as read-only in mobile browsers. Also, invoke `fitPage` method with `FitPageWidth` parameter in document change event, such as to display one full page by adjusting the zoom factor.
-
+At present, the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component is not responsive on mobile, and the editing functionalities are not ensured in mobile browsers. However, it works properly as a document viewer in mobile browsers. Hence, it is recommended to switch the Document Editor component to read-only mode in mobile browsers. Also, invoke the `fitPage` method with the `FitPageWidth` parameter in the document change event to display one full page by adjusting the zoom factor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
 {% include code-snippet/document-editor/asp-net-core/mobile-view/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Mobile-view.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
-
-
-N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in DocumentEditorContainer and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in DocumentEditor based on your requirement to change component to read only mode.
+N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) property in the DocumentEditorContainer and the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) property in the DocumentEditor, based on your requirement, to change the component to read-only mode.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-header-and-footer-edit-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-header-and-footer-edit-in-document-editor.md
@@ -1,21 +1,21 @@
----
+﻿---
 layout: post
-title: How to disable header and footer edit in Document Editor Component
-description: Learn how to to disable header and footer edit in Document from the Syncfusion Document Editor component of Syncfusion Essential JS2 and more.
+title: How to disable header and footer edit in Syncfusion DOCX Editor
+description: Learn how to disable header and footer editing in the Syncfusion Document Editor component of Essential JS 2 and more.
 platform: document-processing
 control: Disable Header And Footer
 documentation: ug
 ---
 
-# How to disable header and footer edit in  Document Editor component
+# Disable header and footer edit in ASP.NET Core Document Editor
 
 ## Disable header and footer edit in DocumentEditorContainer instance
 
-You can use [`restrictEditing`] property to disable header and footer editing based on selection context type.
+You can use the [`restrictEditing`] property to disable header and footer editing based on selection context type.
 
-RestrictEditing allows you to restrict the document modification and makes the Document read only mode. So, by using this property, and if selection inside header or footer, you can set this property as true.
+RestrictEditing allows you to restrict the document modification and makes the document read-only mode. So, by using this property, and if the selection is inside header or footer, you can set this property as true.
 
-The following example code illustrates how to header and footer edit in `DocumentEditorContainer` instance.
+The following example code illustrates how to disable header and footer edit in the `DocumentEditorContainer` instance.
 
 
 {% tabs %}
@@ -23,11 +23,12 @@ The following example code illustrates how to header and footer edit in `Documen
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/disable-header-footer/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="document-editor.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
-Otherwise, you can disable clicking inside Header or Footer by using [`closeHeaderFooter`] API in selection module.
+Otherwise, you can disable clicking inside Header or Footer by using the [`closeHeaderFooter`] API in the selection module.
 
-The following example code illustrates how to close header and footer when selection is inside header or footer in `DocumentEditorContainer` instance.
+The following example code illustrates how to close header and footer when the selection is inside header or footer in the `DocumentEditorContainer` instance.
 
 
 {% tabs %}
@@ -35,14 +36,15 @@ The following example code illustrates how to close header and footer when selec
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/disable-header-footer-close/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="document-editor.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Disable header and footer edit in DocumentEditor instance
 
-Like restrictEditing, you can use [`isReadOnly`] property in Document editor to disable header and footer edit.
+Like restrictEditing, you can use the [`isReadOnly`] property in the Document Editor to disable header and footer edit.
 
-The following example code illustrates how to header and footer edit in `DocumentEditor` instance.
+The following example code illustrates how to disable header and footer edit in the `DocumentEditor` instance.
 
 
 {% tabs %}
@@ -50,5 +52,6 @@ The following example code illustrates how to header and footer edit in `Documen
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/disable-header-footer-documenteditor/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="document-editor.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 
-# Disable optimized text measuring in Document Editor
+# Disable optimized text measuring in ASP.NET Core Document Editor
 
 Starting from v19.3.0.x, the accuracy of text size measurements in the Document Editor is improved to match Microsoft Word pagination for most Word documents. This improvement is included as the default behavior along with an optional API `enableOptimizedTextMeasuring` in the Document Editor settings.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: Disable Optimized Text Measuring in Document Editor Component
-description: Learn here all about disable optimized text measuring in Syncfusion Document Editor component of syncfusion and more.
+title: Disable Optimized Text Measuring in Syncfusion DOCX Editor Component
+description: Learn here all about disabling optimized text measuring in the Syncfusion Document Editor component and more.
 platform: document-processing
 control: Disable Optimized Text Measuring
 documentation: ug
 ---
 
 
-# How to disable optimized text measuring in Document Editor component
+# Disable optimized text measuring in Document Editor
 
-Starting from v19.3.0.x, the accuracy of text size measurements in Document editor is improved such as to match Microsoft Word pagination for most Word documents. This improvement is included as default behavior along with an optional API `enableOptimizedTextMeasuring` in Document editor settings.
+Starting from v19.3.0.x, the accuracy of text size measurements in the Document Editor is improved to match Microsoft Word pagination for most Word documents. This improvement is included as the default behavior along with an optional API `enableOptimizedTextMeasuring` in the Document Editor settings.
 
-If you want the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions. Then, you can disable this optimized text measuring improvement, by setting `false` to `enableOptimizedTextMeasuring` property of Document Editor component.
+If you want the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions, then you can disable this optimized text measuring improvement by setting the `enableOptimizedTextMeasuring` property of the Document Editor component to `false`.
 
 ## Disable optimized text measuring in `DocumentEditorContainer` instance
 
-The following example code illustrates how to disable optimized text measuring improvement in `DocumentEditorContainer` instance.
+The following example code illustrates how to disable the optimized text measuring improvement in the `DocumentEditorContainer` instance.
 
 
 {% tabs %}
@@ -24,13 +24,14 @@ The following example code illustrates how to disable optimized text measuring i
 {% include code-snippet/document-editor/asp-net-core/optimized-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Optimized-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 
 ## Disable optimized text measuring in `DocumentEditor` instance
 
-The following example code illustrates how to disable optimized text measuring improvement in `DocumentEditor` instance.
+The following example code illustrates how to disable the optimized text measuring improvement in the `DocumentEditor` instance.
 
 
 {% tabs %}
@@ -38,5 +39,6 @@ The following example code illustrates how to disable optimized text measuring i
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/optimized-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Optimized-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/enable-ruler-in-document-editor-component.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/enable-ruler-in-document-editor-component.md
@@ -1,17 +1,19 @@
 ---
 layout: post
-title: how to enable ruler in Document Editor Component
-description: Learn how to enable ruler in Document Editor component of Syncfusion Essential JS 2 and more.
+title: How to enable ruler in Syncfusion DOCX Editor Component
+description: Learn how to enable the ruler in the Syncfusion Document Editor component to set margins, tab stops, and indentations for consistent formatting and more.
 platform: document-processing
 control: Enable Ruler
 documentation: ug
 ---
 
-## How to enable ruler in ASP.NET Core Document Editor component
+# Enable ruler in ASP.NET Core Document Editor component
 
-Using ruler we can refer to setting specific margins, tab stops, or indentations within a document to ensure consistent formatting in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+## Enable ruler in Document Editor
 
-The following example illustrates how to enable ruler in Document Editor
+Using the ruler, you can set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
+
+The following example illustrates how to enable the ruler in the Document Editor.
 
 
 {% tabs %}
@@ -25,11 +27,11 @@ The following example illustrates how to enable ruler in Document Editor
 
 
 
-## How to enable ruler in Document Editor Container component
+## Enable ruler in Document Editor Container
 
-Using ruler we can refer to setting specific margins, tab stops, or indentations within a document to ensure consistent formatting in Document Editor Container.
+Using the ruler, you can set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the Document Editor Container.
 
-The following example illustrates how to enable ruler in Document Editor Container.
+The following example illustrates how to enable the ruler in the Document Editor Container.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/export-document-as-pdf.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/export-document-as-pdf.md
@@ -1,25 +1,24 @@
 ---
 layout: post
-title: Export PDF in Document Editor Component |Syncfusion
-description: Learn here all about export document as PDF in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Export PDF in Syncfusion DOCX Editor Component | Syncfusion
+description: Learn here all about exporting the document as PDF in the Syncfusion Document Editor component of Essential JS 2 and more.
 platform: document-processing
 control: Export Document As PDF
 documentation: ug
 ---
 
 
-# How to export the document as PDF in React Document Editor
+# Export the document as PDF in ASP.NET Core Document Editor
 
-This article explains how to export the document as PDF format. You can export the document as PDF in following ways:
+This article explains how to export the document as a PDF. You can export the document as PDF in the following ways:
 
-## Export the document as PDF in client-side
+## Export the document as PDF on the client-side
 
-Use [`pdf export component`](https://www.npmjs.com/package/@syncfusion/ej2-pdf-export) in application level to export the document as PDF using `exportAsImage` API. Here, all pages will be converted to image and inserted as PDF pages (works like print as PDF).
+Use the [`pdf export component`](https://www.npmjs.com/package/@syncfusion/ej2-pdf-export) at the application level to export the document as PDF using the `exportAsImage` API. Here, all pages will be converted to images and inserted as PDF pages (works like print as PDF).
 
->Note: 
-* The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) exports PDFs by converting pages into images on the client side, which may slightly increase file size compared to text-based PDFs.
-* Text search is not supported in the exported PDF, as the content is stored as images.
-* You can install the PDF export packages from this [`link`](https://www.npmjs.com/package/@syncfusion/ej2-pdf-export).
+N> 1. The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) exports PDFs by converting pages into images on the client side, which may slightly increase the file size compared to text-based PDFs.
+N> 2. Text search is not supported in the exported PDF, as the content is stored as images.
+N> 3. You can install the PDF export packages from this [`link`](https://www.npmjs.com/package/@syncfusion/ej2-pdf-export).
 
 
 {% tabs %}
@@ -33,13 +32,13 @@ Use [`pdf export component`](https://www.npmjs.com/package/@syncfusion/ej2-pdf-e
 
 
 
-## Export document as PDF in server-side using DocIO
+## Export document as PDF on the server-side using DocIO
 
-With the help of [`Syncfusion DocIO`](https://help.syncfusion.com/file-formats/docio/word-to-pdf), you can export the document as PDF in server-side. Here, you can search the text.
+With the help of [`Syncfusion DocIO`](https://help.syncfusion.com/file-formats/docio/word-to-pdf), you can export the document as PDF on the server-side. Here, you can search the text.
 
-The following way illustrates how to convert the document as PDF:
+The following steps illustrate how to convert the document as PDF:
 
-* Using `serialize` API, convert the document as Sfdt and send it to server-side.
+* Using the `serialize` API, convert the document as SFDT and send it to the server-side.
 
 
 {% tabs %}
@@ -53,8 +52,8 @@ The following way illustrates how to convert the document as PDF:
 
 
 
-* Using Save API in server-side, you can convert the sfdt to stream.
-* Finally, convert the stream to PDF using `Syncfusion.DocIORenderer.Net.Core` library.
+* Using the Save API on the server-side, you can convert the SFDT to a stream.
+* Finally, convert the stream to a PDF using the `Syncfusion.DocIORenderer.Net.Core` library.
 
 ```csharp
 [AcceptVerbs("Post")]


### PR DESCRIPTION
Address ASP.NET Core UG documentation for DOCX Editor

How to ==>  Deploy document editor component for mobile
<img width="805" height="309" alt="image" src="https://github.com/user-attachments/assets/6f2fed30-e04d-4565-9698-b683a3e6f501" />

How To ==> Disable header and footer edit in document editor
<img width="1040" height="311" alt="image" src="https://github.com/user-attachments/assets/42917c06-0551-4a38-a3bb-eadcdc209e52" />

How to ==> Disable optimized text measuring
<img width="805" height="316" alt="image" src="https://github.com/user-attachments/assets/60ba04a9-e0cf-469b-adfd-059377d6daea" />

How to ==> Enabling ruler in document editor component
<img width="720" height="319" alt="image" src="https://github.com/user-attachments/assets/8b18280e-a5bd-4c82-b495-f59798642f70" />

How to ==> Export document as PDF
<img width="720" height="313" alt="image" src="https://github.com/user-attachments/assets/4a77bd75-fb73-42b2-ad60-5f8ea5a33d6c" />


