### PR TITLE
Task(1044664): Addressing ASP.NET Core DOCX Editor ug documentation page issue

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-current-word.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-current-word.md
@@ -1,19 +1,19 @@
 ---
 layout: post
-title: Get current Word/Para in Document editor control | Syncfusion
-description: Learn how to select and retrieve current word and Paragraph from the Syncfusion Document Editor Component
+title: Get current Word/Para in Syncfusion DOCX Editor control | Syncfusion
+description: Learn how to select and retrieve the current word and paragraph from the Syncfusion Document Editor component.
 platform: document-processing
-control: Get The Current Word And Paragrapgh
-documentation: ug 
+control: Get The Current Word And Paragraph
+documentation: ug
 ---
 
-# How to select and retrieve the word and paragraph in current cursor position in Document Editor component
+# Get current word and paragraph in Document Editor component
 
-You can get the current word or paragraph content from the  [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component as plain text and SFDT (rich text).
+You can get the current word or paragraph content from the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component as plain text and SFDT (rich text).
 
 ## Select and get the word in current cursor position
 
-You can use [`selectCurrentWord`] API in selection module to select the current word at cursor position and use [`text`] API to get the selected content as plain text from Document Editor component.
+You can use the [`selectCurrentWord`] API in the selection module to select the current word at the cursor position and use the [`text`] API to get the selected content as plain text from the Document Editor component.
 
 The following example code illustrates how to select and get the current word as plain text.
 
@@ -30,7 +30,7 @@ The following example code illustrates how to select and get the current word as
 
 ## Select and get the paragraph in current cursor position
 
-You can use [`selectParagraph`] API in selection module to select the current paragraph at cursor position and use [`text`] API or [`sfdt`] API to get the selected content as plain text or SFDT from Document Editor component.
+You can use the [`selectParagraph`] API in the selection module to select the current paragraph at the cursor position and use the [`text`] API or the [`sfdt`] API to get the selected content as plain text or SFDT from the Document Editor component.
 
 The following example code illustrates how to select and get the current paragraph as SFDT.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-the-selected-content.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-the-selected-content.md
@@ -1,20 +1,20 @@
 ---
 layout: post
-title: Get Selected Content in Document Editor Component | Syncfusion
-description: Learn here all about get the selected content in Syncfusion Document Editor component of Syncfusion Essential JS 2 and more.
+title: Get Selected Content in Syncfusion DOCX Editor Component | Syncfusion
+description: Learn here all about getting the selected content in the Syncfusion Document Editor component of Essential JS 2 and more.
 platform: document-processing
 control: Get The Selected Content
 documentation: ug
 ---
 
 
-# How to get the selected content in Document Editor component
+# Get the selected content in the ASP.NET Core Document Editor
 
 You can get the selected content from the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component as plain text and SFDT (rich text).
 
 ## Get the selected content as plain text
 
-You can use `text` API to get the selected content as plain text from React Document Editor component.
+You can use the `text` API to get the selected content as plain text from the ASP.NET Core Document Editor component.
 
 
 {% tabs %}
@@ -26,15 +26,15 @@ You can use `text` API to get the selected content as plain text from React Docu
 {% endtabs %}
 
 
-You can add the following custom options using this API,
+You can add the following custom options using this API:
 
-* Save or export the selected text as text file.
+* Save or export the selected text as a text file.
 * Search the selected text in Google or other search engines.
-* Show synonyms for the selected word in context menu and replace with selected synonym using the setter method of same API.
+* Show synonyms for the selected word in the context menu and replace with the selected synonym using the setter method of the same API.
 
 ## Get the selected content as SFDT (rich text)
 
-You can use `sfdt` API to get the selected content as rich text from React Document Editor component.
+You can use the `sfdt` API to get the selected content as rich text from the ASP.NET Core Document Editor component.
 
 
 {% tabs %}
@@ -46,8 +46,8 @@ You can use `sfdt` API to get the selected content as rich text from React Docum
 {% endtabs %}
 
 
-You can add the following custom options using this API,
+You can add the following custom options using this API:
 
-* Save or export the selected content as SFDT file.
-* Get the content of a bookmark in Word document as SFDT by selecting a bookmark using `select bookmark` API.
-* Create template content that can be inserted to multiple documents in cursor position using `paste` API.
+* Save or export the selected content as an SFDT file.
+* Get the content of a bookmark in a Word document as SFDT by selecting a bookmark using the `selectBookmark` API.
+* Create template content that can be inserted into multiple documents at the cursor position using the `paste` API.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/hide-tool-bar-and-properties-pane.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/hide-tool-bar-and-properties-pane.md
@@ -1,21 +1,21 @@
 ---
 layout: post
-title: Hide the default tool bar and properties pane in Document Editor Component
-description: Learn how to hide the default tool bar properties pane from the Syncfusion Document Editor Component
+title: Hide toolbar and properties pane in DOCX Editor | Syncfusion
+description: Learn how to hide the default toolbar and properties pane from the Syncfusion Document Editor component.
 platform: document-processing
 control: Hide The Default Tool Bar And Properties Pane
 documentation: ug
 ---
 
-# How to hide the default tool bar and properties pane in Document Editor component
+# Hide toolbar and properties pane in Document Editor component
 
-**Document editor container** provides the main document view area along with the built-in toolbar and properties pane.
+The **Document Editor container** provides the main document view area along with the built-in toolbar and properties pane.
 
-**[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor)** provides just the main document view area. Here, the user can compose, view, and edit the Word documents. You may prefer to use this component when you want to design your own UI options for your application.
+**[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor)** provides just the main document view area. Here, the user can compose, view, and edit Word documents. You may prefer to use this component when you want to design your own UI options for your application.
 
 ## Hide the properties pane
 
-By default, Document editor container has built-in properties pane which contains options for formatting text, table, image and header and footer. You can use [`showPropertiesPane`] API in `DocumentEditorContainer` to hide the properties pane.
+By default, the Document Editor container has a built-in properties pane which contains options for formatting text, tables, images, and the header and footer. You can use the [`showPropertiesPane`] API in `DocumentEditorContainer` to hide the properties pane.
 
 The following example code illustrates how to hide the properties pane.
 
@@ -25,14 +25,15 @@ The following example code illustrates how to hide the properties pane.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/hide-the-default-propertiespane/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Hide-the-default-propertiespane.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-N> Positioning and customizing the properties pane in Document editor container is not possible. Instead, you can hide the exiting properties pane and create your own pane using public API's.
+N> Positioning and customizing the properties pane in the Document Editor container is not possible. Instead, you can hide the existing properties pane and create your own pane using public APIs.
 
 ## Hide the toolbar
 
-You can use [`enableToolbar`] API in `DocumentEditorContainer` to hide the existing toolbar.
+You can use the [`enableToolbar`] API in `DocumentEditorContainer` to hide the existing toolbar.
 
 The following example code illustrates how to hide the existing toolbar.
 
@@ -42,7 +43,8 @@ The following example code illustrates how to hide the existing toolbar.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/hide-the-default-toolbar/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Hide-the-default-toolbar.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## See Also

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-page-number-and-navigate-to-page.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-page-number-and-navigate-to-page.md
@@ -1,23 +1,23 @@
 ---
 layout: post
-title: Insert Page number and Navigate to specific page Document Editor Component
+title: Insert page number and navigate to page in DOCX Editor | Syncfusion
 description: Learn how to Insert Page number and Navigate to specific page from the Syncfusion Document Editor Component
 platform: document-processing
 control: Insert Page number And Navigate To Specific Page
 documentation: ug
 ---
 
-# How to insert page number and navigate to specific page in Document Editor component
+# Insert page number and navigate to page in Document Editor component
 
-You can insert page number and navigate to specific page in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component by following ways.
+You can insert a page number and navigate to a specific page in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component in the following ways.
 
 ## Insert page number
 
-You can use [`insertPageNumber`] API in editor module to insert the page number in current cursor position. By default, Page number will insert in Arabic number style. You can change it, by providing the number style in parameter.
+You can use the [`insertPageNumber`] API in the editor module to insert the page number at the current cursor position. By default, the page number will be inserted in Arabic number style. You can change it by providing the number style in the parameter.
 
-N> Currently, Document Editor have options to insert page number at current cursor position.
+N> Currently, the Document Editor has options to insert a page number at the current cursor position.
 
-The following example code illustrates how to insert page number in header.
+The following example code illustrates how to insert a page number in the header.
 
 
 {% tabs %}
@@ -25,10 +25,11 @@ The following example code illustrates how to insert page number in header.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/insert-page-number/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Insert-page-number.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-Also, you use [`insertField`] API in Editor module to insert the Page number in current position
+You can also use the [`insertField`] API in the Editor module to insert the page number at the current position.
 
 ```typescript
 //Current page number
@@ -37,9 +38,9 @@ container.documentEditor.editor.insertField('PAGE \* MERGEFORMAT', '1');
 
 ## Get page count
 
-You can use [`pageCount`] API to gets the total number of pages in Document.
+You can use the [`pageCount`] API to get the total number of pages in the document.
 
-The following example code illustrates how to get the number of pages in Document.
+The following example code illustrates how to get the number of pages in the document.
 
 
 {% tabs %}
@@ -47,14 +48,15 @@ The following example code illustrates how to get the number of pages in Documen
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/page-count/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Page-count.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
 ## Navigate to specific page
 
-You can use [`goToPage`] API in Selection module to move selection to the start of the specified page number.
+You can use the [`goToPage`] API in the Selection module to move the selection to the start of the specified page number.
 
-The following example code illustrates how to move selection to specific page.
+The following example code illustrates how to move the selection to a specific page.
 
 
 {% tabs %}
@@ -62,5 +64,6 @@ The following example code illustrates how to move selection to specific page.
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/go-to-page/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Go-to-page.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-in-current-position.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-text-in-current-position.md
@@ -1,24 +1,24 @@
 ---
 layout: post
-title: Insert text, paragraph and rich-text content in Document Editor Component | Syncfusion
-description: Learn how to insert text, paragraph and rich-text content in Document Editor Component
+title: Insert text, paragraph, and rich text in DOCX Editor | Syncfusion
+description: Learn how to insert text, a paragraph, and rich-text content at the current cursor position in the Syncfusion ASP.NET Core Document Editor component.
 platform: document-processing
 control: Insert Text, Paragraph And Rich-Text Content
 documentation: ug
 ---
 
-# How to insert text, paragraph and rich-text content in Document Editor component
+# Insert text, paragraph, and rich text in Document Editor component
 
-You can insert the text, paragraph and rich-text content in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component.
+You can insert text, a paragraph, and rich-text content in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component.
 
-## Insert text in current cursor position
+## Insert text at the current cursor position
 
-You can use [`insertText`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/editor/#inserttext) API in editor module to insert the text in current cursor position.
+You can use the [`insertText`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor/editor#inserttext) API in the editor module to insert the text at the current cursor position.
 
-The following example code illustrates how to add the text in current selection.
+The following example code illustrates how to add the text in the current selection.
 
 ```typescript
-// It will insert the provided text in current selection
+// It will insert the provided text in the current selection
 this.container.documentEditor.editor.insertText('Syncfusion');
 ```
 
@@ -27,29 +27,30 @@ this.container.documentEditor.editor.insertText('Syncfusion');
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/insert-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Insert-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-## Insert paragraph in current cursor position
+## Insert a paragraph at the current cursor position
 
-To insert new paragraph at current selection, you can can use [`insertText`] API with parameter as `\r\n` or `\n`.
+To insert a new paragraph at the current selection, you can use the [`insertText`] API with the parameter as `\r\n` or `\n`.
 
-The following example code illustrates how to add the new paragraph in current selection.
+The following example code illustrates how to add a new paragraph in the current selection.
 
 ```typescript
-// It will add the new paragraph in current selection
+// It will add a new paragraph in the current selection
 this.container.documentEditor.editor.insertText('\n');
 ```
 
 ## Insert the rich-text content
 
-To insert the HTML content, you have to convert the HTML content to SFDT Format using [`web service`]. Then use [`paste`] API to insert the sfdt at current cursor position.
+To insert HTML content, you have to convert the HTML content to SFDT format using the [`web service`](https://ej2.syncfusion.com/javascript/documentation/api/document-editor). Then use the [`paste`] API to insert the SFDT at the current cursor position.
 
-N> HTML string should be well formatted html. [`DocIO`](https://help.syncfusion.com/file-formats/docio/html) support only well formatted XHTML.  
+N> The HTML string should be well-formatted HTML. [`DocIO`](https://help.syncfusion.com/file-formats/docio/html) supports only well-formatted XHTML.  
 
-The following example illustrates how to insert the HTML content at current cursor position.
+The following example illustrates how to insert the HTML content at the current cursor position.
 
-* Send the HTML content to server side for SFDT conversion. Refer to the following example to send the HTML content to server side and inserting it in current cursor position.
+* Send the HTML content to the server side for SFDT conversion. Refer to the following example to send the HTML content to the server side and insert it at the current cursor position.
 
 
 {% tabs %}
@@ -57,17 +58,18 @@ The following example illustrates how to insert the HTML content at current curs
 {% include code-snippet/document-editor/asp-net-core/document-editor-container/insert-rich-text/tagHelper %}
 {% endhighlight %}
 {% highlight c# tabtitle="Insert-rich-text.cs" %}
-{% endhighlight %}{% endtabs %}
+{% endhighlight %}
+{% endtabs %}
 
 
-* Refer the following code example for server-side web implementation for HTML conversion using DocumentEditor.
+* Refer to the following code example for the server-side web implementation for HTML conversion using the DocumentEditor.
 
 ```c#
 //API controller for the conversion.
 [HttpPost]
 public string LoadString([FromBody]InputParameter data)
 {
-    // You can also load HTML file/string from server side.
+    // You can also load an HTML file/string from the server side.
     Syncfusion.EJ2.DocumentEditor.WordDocument document = Syncfusion.EJ2.DocumentEditor.WordDocument.LoadString(data.content, FormatType.Html); // Convert the HTML to SFDT format.
     string json = Newtonsoft.Json.JsonConvert.SerializeObject(document);
     document.Dispose();


### PR DESCRIPTION
Addressing ASP.NET Core DOCX Editor ug documentation issues

How to ==> Get current word
<img width="781" height="308" alt="image" src="https://github.com/user-attachments/assets/81c873d8-dff3-43ae-8317-c52968cebcaf" />

How to ==> Getting selected content

<img width="774" height="274" alt="image" src="https://github.com/user-attachments/assets/e363b5e9-80ba-462c-bb46-50b240d5da3f" />

How to ==> Toolbar and properties pane
<img width="761" height="274" alt="image" src="https://github.com/user-attachments/assets/22e4607c-78dc-4a65-87e0-91da67e3a2a9" />
How to ==> Insert page number and navigate to page
<img width="555" height="303" alt="image" src="https://github.com/user-attachments/assets/6b2f14bc-9f66-473c-8863-7bc7e802c105" />

How to ==> Insert text in current position
<img width="883" height="287" alt="image" src="https://github.com/user-attachments/assets/78cb2898-36c5-43d7-9592-b89c5cecbba9" />



