### PR TITLE
Task(1050024) - Resolved redundant keyword usage in ASP .NET Core DOCX Editor

### DIFF
--- a/Document-Processing/Word/Word-Processor/asp-net-core/bookmark.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/bookmark.md
@@ -62,7 +62,7 @@ container.documentEditor.selection.getBookmarks(false);
 
 ## Show or Hide Bookmark
 
-You can show or hide the bookmark indicators around bookmarked items in Document Editor component.
+You can show or hide the bookmark indicators around bookmarked items in DOCX Editor component.
 
 The following example code illustrates how to show or hide the bookmark indicators around bookmarked items.
 
@@ -92,7 +92,7 @@ container.documentEditor.editor.insertText("Hello World");
 
 ## Bookmark Dialog
 
-The following example shows how to open the bookmark dialog in Document Editor.
+The following example shows how to open the bookmark dialog in DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -105,7 +105,7 @@ The following example shows how to open the bookmark dialog in Document Editor.
 
 ## Online Demo
 
-Explore how to insert and manage bookmarks in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/hyperlinksandbookmarks#/tailwind3).
+Explore how to insert and manage bookmarks in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/hyperlinksandbookmarks#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/chart.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/chart.md
@@ -9,9 +9,9 @@ documentation: ug
 
 # Charts in ASP.NET Core DOCX Editor
 
-[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) provides chart preservation support. Using Document Editor, you can view charts from your Word document.
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) provides chart preservation support. Using DOCX Editor, you can view charts from your Word document.
 
-The following example shows chart preservation in the Document Editor.
+The following example shows chart preservation in the DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -24,7 +24,7 @@ The following example shows chart preservation in the Document Editor.
 
 ## Supported Chart Types
 
-The following chart types are supported in the Document Editor:
+The following chart types are supported in the DOCX Editor:
 * Scatter_Markers
 * Bubble
 * Area
@@ -47,4 +47,4 @@ The following chart types are supported in the Document Editor:
 
 ## Online Demo
 
-Explore how to preserve charts in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/chart#/tailwind3).
+Explore how to preserve charts in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/chart#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/clipboard.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/clipboard.md
@@ -14,7 +14,7 @@ documentation: ug
 
 ## Copy
 
-Copy a portion of the document to the system clipboard using the built-in context menu of the Document Editor. You can also do it programmatically using the following sample code.
+Copy a portion of the document to the system clipboard using the built-in context menu of the DOCX Editor. You can also do it programmatically using the following sample code.
 
 ```typescript
 container.documentEditor.selection.copy();
@@ -22,7 +22,7 @@ container.documentEditor.selection.copy();
 
 ## Cut
 
-Cut a portion of the document to the system clipboard using the built-in context menu of the Document Editor. You can also do it programmatically using the following sample code.
+Cut a portion of the document to the system clipboard using the built-in context menu of the DOCX Editor. You can also do it programmatically using the following sample code.
 
 ```typescript
 container.documentEditor.editor.cut();
@@ -30,18 +30,18 @@ container.documentEditor.editor.cut();
 
 ## Paste
 
-Due to limitations, you can paste content from the system clipboard as plain text in the Document Editor only using the "Ctrl + V" keyboard shortcut.
+Due to limitations, you can paste content from the system clipboard as plain text in the DOCX Editor only using the "Ctrl + V" keyboard shortcut.
 
 N> Due to browser limitations of getting content from the system clipboard, paste using the API and context menu options doesn't work.
 
 ## Local paste
 
-The Document Editor exposes an API to enable local paste within the control. On enabling this, the following is performed:
+The DOCX Editor exposes an API to enable local paste within the control. On enabling this, the following is performed:
 
 * Selected contents will be stored to an internal clipboard in addition to the system clipboard.
 * Clipboard paste will be overridden, and internally stored data that has formatted text will be pasted.
 
-The following example shows how to enable local paste in the Document Editor.
+The following example shows how to enable local paste in the DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -53,7 +53,7 @@ The following example shows how to enable local paste in the Document Editor.
 {% endtabs %}
 
 
-By default, **enableLocalPaste** is false. When local paste is enabled for a Document Editor instance, you can paste content programmatically if the internal clipboard has stored data during the last copy operation.
+By default, **enableLocalPaste** is false. When local paste is enabled for a DOCX Editor instance, you can paste content programmatically if the internal clipboard has stored data during the last copy operation.
 
 
 ```typescript
@@ -64,15 +64,15 @@ container.documentEditor.editor.pasteLocal();
 
 |**EnableLocalPaste** |**Paste behavior details**|
 |--------------------------|----------------------|
-|True |Allows pasting content that is copied from the same Document Editor component alone and prevents pasting content from the system clipboard. Hence, content copied from outside the Document Editor component cannot be pasted.<br>The browser limitation of pasting from the system clipboard using API and context menu options will be resolved. So, you can copy and paste content within the Document Editor component using API and context menu options too.|
-|False|Allows pasting content from the system clipboard. Hence, content copied from both the Document Editor component and outside can be pasted.<br>The browser limitation of pasting from the system clipboard using API and context menu options will remain.|
+|True |Allows pasting content that is copied from the same DOCX Editor component alone and prevents pasting content from the system clipboard. Hence, content copied from outside the DOCX Editor component cannot be pasted.<br>The browser limitation of pasting from the system clipboard using API and context menu options will be resolved. So, you can copy and paste content within the DOCX Editor component using API and context menu options too.|
+|False|Allows pasting content from the system clipboard. Hence, content copied from both the DOCX Editor component and outside can be pasted.<br>The browser limitation of pasting from the system clipboard using API and context menu options will remain.|
 
  
-N> Keyboard shortcut for pasting will work properly in both cases. Copying content from Document editor component and pasting outside will work properly in both cases.
+N> Keyboard shortcut for pasting will work properly in both cases. Copying content from DOCX Editor component and pasting outside will work properly in both cases.
 
 ### Paste options in context menu
 
-In the Document Editor, paste options in the context menu will be in a disabled state if you try to copy/paste content from outside of the Document Editor. It gets enabled when `enableLocalPaste` is `true` and you copy/paste content within the Document Editor.
+In the DOCX Editor, paste options in the context menu will be in a disabled state if you try to copy/paste content from outside of the DOCX Editor. It gets enabled when `enableLocalPaste` is `true` and you copy/paste content within the DOCX Editor.
 
 N> Due to browser limitations of getting content from the system clipboard, paste using the API and context menu options doesn't work. Hence, the paste option is disabled in the context menu.
 
@@ -84,7 +84,7 @@ Alternatively, you can use the keyboard shortcuts:
 
 ## Paste with formatting
 
-The Document Editor provides support to paste the system clipboard data with formatting. To enable clipboard paste with formatting options, set the `enableLocalPaste` property in the Document Editor to `false` and use the `Syncfusion.EJ2.WordEditor.AspNet.Core` .NET Standard library for the ASP.NET Core web API service implementation. This library helps you to paste the system clipboard data with formatting.
+The DOCX Editor provides support to paste the system clipboard data with formatting. To enable clipboard paste with formatting options, set the `enableLocalPaste` property in the DOCX Editor to `false` and use the `Syncfusion.EJ2.WordEditor.AspNet.Core` .NET Standard library for the ASP.NET Core web API service implementation. This library helps you to paste the system clipboard data with formatting.
 
 You can paste your system clipboard data in the following ways:
 
@@ -96,7 +96,7 @@ This paste option appears as follows.
 
 ![Paste options](images/paste.png)
 
-N> When you paste content from an external source into the Document Editor, some formatting or elements may not appear as expected because certain elements are not supported. Refer [here](./unsupported-features) to learn more about unsupported elements.
+N> When you paste content from an external source into the DOCX Editor, some formatting or elements may not appear as expected because certain elements are not supported. Refer [here](./unsupported-features) to learn more about unsupported elements.
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/collaborative-editing/overview.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/collaborative-editing/overview.md
@@ -34,7 +34,7 @@ To support collaborative editing, it is crucial to have a backing system that te
 
 Using the distributed cache or database, all the editing operations are queued in order and conflict resolution is performed using the `Operational Transformation` algorithm.
 
-N> 1. To calculate the average requests per second of your application, assume the Document Editor in your live application is actively used by 1000 users, and each user's edit can trigger 2 to 5 requests per second. The total requests per second of your application will be around 2000 to 5000. In this case, you can finalize a configuration to support around 5000 average requests per second.
+N> 1. To calculate the average requests per second of your application, assume the DOCX Editor in your live application is actively used by 1000 users, and each user's edit can trigger 2 to 5 requests per second. The total requests per second of your application will be around 2000 to 5000. In this case, you can finalize a configuration to support around 5000 average requests per second.
 
 N> 2. The above metrics are based solely on the collaborative editing module. Actual throughput may decrease depending on other server-side interactions, such as document importing, pasting formatted content, editing restrictions, and spell checking. Therefore, it is advisable to monitor your app's traffic and choose a configuration that best suits your needs.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/collaborative-editing/using-redis-cache-asp-net.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/collaborative-editing/using-redis-cache-asp-net.md
@@ -14,7 +14,7 @@ domainurl: ##DomainURL##
 
 ## Prerequisites
 
-The following are needed to enable collaborative editing in the Document Editor:
+The following are needed to enable collaborative editing in the DOCX Editor:
 
 - SignalR
 - Redis
@@ -81,15 +81,15 @@ The configuration and storage size of the Redis cache can be adjusted based on t
 
 ## Integrate collaborative editing in client side
 
-### Step 1: Integrate Document Editor
+### Step 1: Integrate DOCX Editor
 
-Refer to the following documentation to get started with the [ASP.NET Core Document Editor](https://help.syncfusion.com/document-processing/word/word-processor/asp-net-core/getting-started-core).
+Refer to the following documentation to get started with the [ASP.NET Core DOCX Editor](https://help.syncfusion.com/document-processing/word/word-processor/asp-net-core/getting-started-core).
 
 ### Step 2: Enable collaborative editing
 
-To enable collaborative editing, inject `CollaborativeEditingHandler` and set the `enableCollaborativeEditing` property to true in the Document Editor.
+To enable collaborative editing, inject `CollaborativeEditingHandler` and set the `enableCollaborativeEditing` property to true in the DOCX Editor.
 
-The following code snippet demonstrates how to enable collaborative editing in the Document Editor.
+The following code snippet demonstrates how to enable collaborative editing in the DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -102,9 +102,9 @@ The following code snippet demonstrates how to enable collaborative editing in t
 
 ### Step 3: Configure SignalR to send and receive changes
 
-To broadcast changes and receive updates from remote users, configure SignalR in the Document Editor.
+To broadcast changes and receive updates from remote users, configure SignalR in the DOCX Editor.
 
-The following code snippet demonstrates how to configure SignalR in the Document Editor.
+The following code snippet demonstrates how to configure SignalR in the DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -130,7 +130,7 @@ The following code snippet demonstrates how to generate a unique ID and open a d
 
 Changes made on the client side must be transmitted to the server to be broadcast to other connected users.
 
-The following code snippet demonstrates how to send changes to the server using the `contentChange` event in the Document Editor.
+The following code snippet demonstrates how to send changes to the server using the `contentChange` event in the DOCX Editor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/comments.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/comments.md
@@ -73,7 +73,7 @@ documentEditor.editor.insertReplyComment(comment.id, 'Hello world', commentPrope
 
 ## Get Comments
 
-Document Editor lets you get the comments along with their replies and comment properties using `getComments`. The returned object is an array of comments, where each comment exposes `id`, `author`, `dateTime`, `isResolved`, and a `replies` array containing the reply comments with the same properties.
+DOCX Editor lets you get the comments along with their replies and comment properties using `getComments`. The returned object is an array of comments, where each comment exposes `id`, `author`, `dateTime`, `isResolved`, and a `replies` array containing the reply comments with the same properties.
 
 ```typescript
 //Get Comments in the document along with the properties author, date, status.
@@ -120,9 +120,9 @@ documentEditor.editor.deleteAllComments();
 
 ## Protect the document in comments only mode
 
-Document Editor provides support for protecting the document with `CommentsOnly` protection. In this protection, the user can only add or edit comments in the document.
+DOCX Editor provides support for protecting the document with `CommentsOnly` protection. In this protection, the user can only add or edit comments in the document.
 
-Document Editor provides an option to protect and unprotect the document using `enforceProtection` and `stopProtection` API.
+DOCX Editor provides an option to protect and unprotect the document using `enforceProtection` and `stopProtection` API.
 
 
 {% tabs %}
@@ -145,7 +145,7 @@ N> In enforce Protection method, first parameter denotes password and second par
 
 Mention support displays a list of items that users can select or tag from the suggested list. To use this feature, type the `@` character in the comment box and select or tag the user from the suggestion list.
 
-The following example illustrates how to enable mention support in Document Editor
+The following example illustrates how to enable mention support in DOCX Editor
 
 
 {% tabs %}
@@ -176,4 +176,4 @@ To demonstrate a specific use case, let’s consider an example where we want to
 
 ## Online Demo
 
-Explore how to add, view, and manage comments in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/comments#/tailwind3).
+Explore how to add, view, and manage comments in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/comments#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/dialog.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/dialog.md
@@ -16,7 +16,7 @@ documentation: ug
 
 The font dialog lets you modify all text properties for selected contents at once such as bold, italic, underline, font size, font color, strikethrough, subscript, and superscript.
 
-N> To enable the font dialog for a Document Editor instance, set `enableFontDialog` to true. The other dialogs covered on this page are enabled by default and do not require a separate opt-in property.
+N> To enable the font dialog for a DOCX Editor instance, set `enableFontDialog` to true. The other dialogs covered on this page are enabled by default and do not require a separate opt-in property.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/export.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/export.md
@@ -14,14 +14,14 @@ documentation: ug
 
 We are providing two types of save APIs as mentioned below.
 
-|API name|Purpose|Code Snippet for Document Editor|Code Snippet for Document Editor Container|
+|API name|Purpose|Code Snippet for DOCX Editor|Code Snippet for Document Editor Container|
 |--------|---------|----------|----------|
 |save(filename,FormatType):void<br>FormatType: Sfdt or Docx or Dotx or Txt|Creates the document with specified file name and format type. Then, the created file is downloaded in the client browser by default.|documenteditor.save('sample', 'Docx')|container.documentEditor.save('sample', 'Docx')|
 |saveAsBlob(FormatType):Blob|Creates the document in specified format type and returns the created document as Blob.<br>This blob can be uploaded to your required server, database, or file path.|documenteditor.saveAsBlob('Docx')|container.documentEditor.saveAsBlob('Docx')|
 
 ## Sfdt export
 
-The following example shows how to export documents in Document Editor as Syncfusion document text (.sfdt).
+The following example shows how to export documents in DOCX Editor as Syncfusion document text (.sfdt).
 
 
 {% tabs %}
@@ -44,7 +44,7 @@ The following example shows how to export documents in Document Editor as Syncfu
 
 
 
-N> To enable Sfdt export for a Document Editor instance, set [`enableSfdtExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableSfdtExport) to true.
+N> To enable Sfdt export for a DOCX Editor instance, set [`enableSfdtExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableSfdtExport) to true.
 
 ## Word export
 
@@ -70,13 +70,13 @@ The following example shows how to export the document as Word document (.docx).
 {% endtabs %}
 
 
-N> To enable Word export for a Document Editor instance, set [`enableWordExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableWordExport) to true.
+N> To enable Word export for a DOCX Editor instance, set [`enableWordExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableWordExport) to true.
 
 ## Word Template Export 
 
 The following example shows how to export the document as Word Template (.dotx).
 
->Note: The Syncfusion<sup style="font-size:70%">&reg;</sup> Document Editor component's document pagination (page-by-page display) can't be guaranteed for all the Word documents to match the pagination of Microsoft Word application. For more information about [why the document pagination (page-by-page display) differs from Microsoft Word](../asp-net-core/import#why-the-document-pagination-differs-from-microsoft-word).
+>Note: The Syncfusion<sup style="font-size:70%">&reg;</sup> DOCX Editor component's document pagination (page-by-page display) can't be guaranteed for all the Word documents to match the pagination of Microsoft Word application. For more information about [why the document pagination (page-by-page display) differs from Microsoft Word](../asp-net-core/import#why-the-document-pagination-differs-from-microsoft-word).
 
 
 {% tabs %}
@@ -122,11 +122,11 @@ The following example shows how to export document as text document (.txt).
 {% endtabs %}
 
 
-N> To enable text export for a Document Editor instance, set [`enableTextExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableTextExport) to true.
+N> To enable text export for a DOCX Editor instance, set [`enableTextExport`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_EnableTextExport) to true.
 
 ## Export as blob
 
-Document Editor also supports API to store the document into a blob.
+DOCX Editor also supports API to store the document into a blob.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -181,7 +181,7 @@ On the client side, you can consume this web service and save the document as a 
 
 ## Online Demo
 
-Explore how to export Word documents in various formats using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/export#/tailwind3).
+Explore how to export Word documents in various formats using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/export#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/faq/sfdt-faqs.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/faq/sfdt-faqs.md
@@ -14,11 +14,11 @@ The frequently asked questions about SFDT in [ASP.NET Core DOCX Editor](https://
 
 ## What is SFDT format?
 
-SFDT (Syncfusion Document Text) is a JSON-based representation of a DOCX document used internally by the Document Editor. It is not a new or separate file format; instead, it is a structured JSON equivalent of a DOCX file, designed to represent the same document content. SFDT uses a hierarchical key–value structure to describe document elements such as sections, paragraphs, text, styles, tables, and images, closely matching the structure of a Word document.
+SFDT (Syncfusion Document Text) is a JSON-based representation of a DOCX document used internally by the DOCX Editor. It is not a new or separate file format; instead, it is a structured JSON equivalent of a DOCX file, designed to represent the same document content. SFDT uses a hierarchical key–value structure to describe document elements such as sections, paragraphs, text, styles, tables, and images, closely matching the structure of a Word document.
 
 ## Is it possible to modify SFDT?
 
-It is not recommended to modify SFDT directly (either manually or programmatically). The format is designed for internal use by the Document Editor, and even small changes can break the document structure or cause unexpected behavior.
+It is not recommended to modify SFDT directly (either manually or programmatically). The format is designed for internal use by the DOCX Editor, and even small changes can break the document structure or cause unexpected behavior.
 
 ## What are the advantages of SFDT over DOCX?
 
@@ -34,14 +34,14 @@ SFDT is optimized for web-based document editing scenarios.
 
 SFDT is suitable in the following scenarios:
 
-- Applications where documents are edited within the browser using the Document Editor, and the document state needs to be saved and reopened later in the same editor
+- Applications where documents are edited within the browser using the DOCX Editor, and the document state needs to be saved and reopened later in the same editor
 
 - Use cases that require efficient storage in a database and quick reloading for further editing
 
 ## Can SFDT be converted back to DOCX?
 
-Yes. You can easily convert SFDT back to DOCX or other [supported formats](../supported-fileformats) in the Document Editor using the `save` API (for example, `documentEditor.save('sample', 'Docx')`). See the [Export](../export) documentation for details.
+Yes. You can easily convert SFDT back to DOCX or other [supported formats](../supported-fileformats) in the DOCX Editor using the `save` API (for example, `documentEditor.save('sample', 'Docx')`). See the [Export](../export) documentation for details.
 
 ## Are any features unavailable when using SFDT?
 
-No. SFDT fully represents the document structure similar to DOCX, so all Document Editor features are supported when working with SFDT.
+No. SFDT fully represents the document structure similar to DOCX, so all DOCX Editor features are supported when working with SFDT.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/faq/unsupported-file-format.md
@@ -9,14 +9,14 @@ documentation: ug
 
 # Supported File Formats in ASP.NET Core DOCX Editor
 
-If you receive the message "The file format you have selected isn't supported. Please choose a valid format." when opening a document in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor), it typically indicates that the document format is not supported by the current version of the Document Editor. Here are some common reasons for this warning:
+If you receive the message "The file format you have selected isn't supported. Please choose a valid format." when opening a document in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor), it typically indicates that the document format is not supported by the current version of the DOCX Editor. Here are some common reasons for this warning:
 
-1.	Unsupported File Format: The document you are trying to open might be in a format that the Document Editor does not support. Ensure you are using a supported format, such as SFDT.
+1.	Unsupported File Format: The document you are trying to open might be in a format that the DOCX Editor does not support. Ensure you are using a supported format, such as SFDT.
 2.	Corrupted Document: The document file might be corrupted or improperly formatted. Try opening a different document to see if the issue persists.
 
-To avoid this warning, always use the recommended document formats and features supported by the Document Editor. 
+To avoid this warning, always use the recommended document formats and features supported by the DOCX Editor. 
 
-Document Editor supports the following file formats:
+DOCX Editor supports the following file formats:
 
 * Word Document (*.docx)
 * Syncfusion Document Text (*.sfdt)
@@ -28,4 +28,4 @@ Document Editor supports the following file formats:
 * Word 97-2003 Template (*.dot)
 * Word 97-2003 Document (*.doc)
 
-By using these supported formats, you can ensure compatibility and avoid unsupported-format warning messages when opening documents in the Document Editor.
+By using these supported formats, you can ensure compatibility and avoid unsupported-format warning messages when opening documents in the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/feature-module.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/feature-module.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # Feature Modules in ASP.NET Core DOCX Editor
 
-[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the Document Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of Document Editor that can be included as required:
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) features are segregated into individual feature-wise modules to enable selective referencing. By default, the DOCX Editor displays the document in read-only mode. The required modules should be injected to extend its functionality. The following are the selective modules of DOCX Editor that can be included as required:
 * **Print** - Prints the document.
 * **SfdtExport** - Exports the document as Syncfusion Document Text (.SFDT) file.
 * **Selection** - Selects a portion of the document and copies it to the clipboard.
@@ -21,11 +21,11 @@ documentation: ug
 * **EditorHistory** - Maintains the history of editing operations, so that you can perform undo and redo at any time.
 * User interface options such as context menu, options pane, image resizer, and dialogs are available as individual modules.
 
-N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a Document Editor instance.
+N>In addition to injecting the required modules in your application, enable corresponding properties to extend the functionality for a DOCX Editor instance.
 
 Refer to the following table.
 
-| Module | Property to enable the functionality for a Document Editor instance |
+| Module | Property to enable the functionality for a DOCX Editor instance |
 |---|---|
 |Print|`<ejs-documenteditor enablePrint= true ></ejs-documenteditor>`|
 |SfdtExport|`<ejs-documenteditor enableSfdtExport= true ></ejs-documenteditor>`|

--- a/Document-Processing/Word/Word-Processor/asp-net-core/fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/fields.md
@@ -23,11 +23,11 @@ documenteditor.editor.insertField(fieldCode, fieldResult);
 
 ```
 
-N> Document Editor does not validate or process the field code or field result. It simply inserts the field with specified field information.
+N> DOCX Editor does not validate or process the field code or field result. It simply inserts the field with specified field information.
 
 ## Update fields
 
-Document Editor provides support for updating bookmark cross reference field.
+DOCX Editor provides support for updating bookmark cross reference field.
 
 ```typescript
 //Update all the bookmark cross reference field in the document.
@@ -38,7 +38,7 @@ Bookmark cross reference fields can be updated through UI by using update fields
 
 ![Update bookmark cross reference field.](images/updatefields.png)
 
-The following type of fields are automatically updated in Document Editor.
+The following type of fields are automatically updated in DOCX Editor.
 
 * NUMPAGES
 * SECTION

--- a/Document-Processing/Word/Word-Processor/asp-net-core/find-and-replace.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/find-and-replace.md
@@ -31,7 +31,7 @@ You can close the options pane by pressing `Esc` key.
 
 ## Search
 
-The `Search` module of Document Editor exposes the following APIs:
+The `Search` module of DOCX Editor exposes the following APIs:
 
 |API Name|Type |Description|
 |---|---|---|

--- a/Document-Processing/Word/Word-Processor/asp-net-core/form-fields.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/form-fields.md
@@ -101,9 +101,9 @@ documentEditor.resetFormFields();
 
 ## Protect the document in form filling mode
 
-Document Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
+DOCX Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
 
-Document Editor provides an option to protect and unprotect document using `enforceProtection` and `stopProtection` API.
+DOCX Editor provides an option to protect and unprotect document using `enforceProtection` and `stopProtection` API.
 
 
 {% tabs %}
@@ -120,4 +120,4 @@ N> In enforce Protection method, first parameter denotes password and second par
 
 ## Online Demo
 
-Explore how to insert and manage form fields in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/formfields#/tailwind3).
+Explore how to insert and manage form fields in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/formfields#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/global-local.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/global-local.md
@@ -12,13 +12,13 @@ documentation: ug
 
 ## Localization
 
-The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows you to localize the default text content of the Document Editor. The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component has static text on some features (such as find & replace, context menu, and dialogs) that can be changed to other cultures (Arabic, German, French, and more) by defining the locale value and translation object. To see the editor rendered with right-to-left flow, refer to the [Right-to-Left (RTL) sample](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
+The [`Localization`](https://ej2.syncfusion.com/aspnetcore/documentation/common/localization) library allows you to localize the default text content of the DOCX Editor. The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component has static text on some features (such as find & replace, context menu, and dialogs) that can be changed to other cultures (Arabic, German, French, and more) by defining the locale value and translation object. To see the editor rendered with right-to-left flow, refer to the [Right-to-Left (RTL) sample](https://ej2.syncfusion.com/aspnetcore/DocumentEditor/RightToLeft#/material).
 
 N> Refer the [Locale](https://github.com/syncfusion/ej2-locale).
 
-## Document Editor
+## DOCX Editor
 
-The following list of properties and its values are used in the Document Editor.
+The following list of properties and its values are used in the DOCX Editor.
 
 Locale keywords |Text
 -----|-----

--- a/Document-Processing/Word/Word-Processor/asp-net-core/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/header-footer.md
@@ -87,7 +87,7 @@ documenteditor.selection.closeHeaderFooter()
 
 ## Online Demo
 
-Explore how to add and customize headers and footers in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/headersandfooters#/tailwind3).
+Explore how to add and customize headers and footers in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/headersandfooters#/tailwind3).
 
 
 ## See Also

--- a/Document-Processing/Word/Word-Processor/asp-net-core/history.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/history.md
@@ -27,7 +27,7 @@ Inject the `EditorHistory` module in your application to provide history preserv
 {% endtabs %}
 
 
-You can enable or disable history preservation for a Document Editor instance any time using the `enableEditorHistory` property.
+You can enable or disable history preservation for a DOCX Editor instance any time using the `enableEditorHistory` property.
 
 ```typescript
 editor.enableEditorHistory = false;
@@ -35,7 +35,7 @@ editor.enableEditorHistory = false;
 
 ## Undo and redo
 
-You can perform undo and redo by `CTRL+Z` and `CTRL+Y` keyboard shortcuts. Document Editor exposes API to do it programmatically. To undo the last editing operation in Document Editor, refer to the following sample code.
+You can perform undo and redo by `CTRL+Z` and `CTRL+Y` keyboard shortcuts. DOCX Editor exposes API to do it programmatically. To undo the last editing operation in DOCX Editor, refer to the following sample code.
 
 ```typescript
 editor.editorHistory.undo();
@@ -49,7 +49,7 @@ editor.editorHistory.redo();
 
 ## Stack size
 
-History of editing actions will be maintained in stack, so that the last item will be reverted first. By default, Document Editor limits the size of undo and redo stacks to 500 each respectively. However, you can customize this limit.
+History of editing actions will be maintained in stack, so that the last item will be reverted first. By default, DOCX Editor limits the size of undo and redo stacks to 500 each respectively. However, you can customize this limit.
 
 ```typescript
 editor.editorHistory.undoLimit = 400;

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/auto-save-document-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/auto-save-document-in-document-editor.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Auto Save to AWS S3 in ASP.NET Core DOCX Editor | Syncfusion
 description: Automatically save edited documents to AWS S3 at regular intervals in Syncfusion® ASP.NET Core DOCX Editor for reliable cloud-based storage.
 platform: document-processing
-control: Auto Save Document In Document Editor
+control: Auto Save Document In DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/auto-save-document.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/auto-save-document.md
@@ -3,14 +3,14 @@ layout: post
 title: How to Auto Save Document in ASP.NET Core DOCX Editor | Syncfusion
 description: Automatically save edited documents to the server at regular intervals in Syncfusion® ASP.NET Core DOCX Editor to prevent data loss.
 platform: document-processing
-control: Auto Save Document In Document Editor
+control: Auto Save Document In DOCX Editor
 documentation: ug
 ---
 
 
 # How to Auto Save Document in ASP.NET Core DOCX Editor
 
-Learn how to auto-save a document to the server using the Syncfusion Document Editor component. You can automatically save the edited content at regular intervals, which helps reduce the risk of data loss by saving an open document automatically at customized intervals.
+Learn how to auto-save a document to the server using the Syncfusion DOCX Editor component. You can automatically save the edited content at regular intervals, which helps reduce the risk of data loss by saving an open document automatically at customized intervals.
 
 The example below saves the document to the server every 10 seconds by posting the editor's DOCX blob to a server endpoint through the `contentChange` event.
 
@@ -50,7 +50,7 @@ public string AutoSave()
 
 ## Online Demo
 
-Explore how to automatically save Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/autosave#/tailwind3).
+Explore how to automatically save Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/autosave#/tailwind3).
 
 ## See Also
 * [AutoSave document in DocumentEditor](./auto-save-document-in-document-editor)

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/change-the-cursor-color-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/change-the-cursor-color-in-document-editor.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # How to Change Cursor Color in ASP.NET Core DOCX Editor
 
-[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) default cursor color is black. You can change the color by overriding the CSS property using the class name. The Document Editor cursor CSS uses a class named `e-de-blink-cursor`.
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) default cursor color is black. You can change the color by overriding the CSS property using the class name. The DOCX Editor cursor CSS uses a class named `e-de-blink-cursor`.
 
 Refer to the following code snippet to change the cursor color to red.
 
@@ -21,4 +21,5 @@ border-left: 1px solid red !important;
 
 Output will be like below:
 
-![Change the cursor color in Document Editor](../images/cursor-css.png)
+![Change the cursor color in DOCX Editor](../images/cursor-css.png)
+

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-color-picker.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-color-picker.md
@@ -12,7 +12,7 @@ documentation: ug
 
 [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) provides options to customize the color picker using `colorPickerSettings` in `DocumentEditorSettings`. The color picker offers customization options for the default appearance, by allowing selection between Picker or Palette mode, for font and border colors.
 
-Similarly, you can use the `documentEditorSettings` property for the Document Editor as well.
+Similarly, you can use the `documentEditorSettings` property for the DOCX Editor as well.
 
 
 {% tabs %}
@@ -40,4 +40,5 @@ N> According to the Word document specifications, it is not possible to modify t
 
 ## Online demo
 
-Explore how to customize the color picker in the ASP.NET Core Document Editor for formatting Word documents in this live [ASP.NET Core Color Picker Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/colorpickercustomization#/tailwind3).
+Explore how to customize the color picker in the ASP.NET Core DOCX Editor for formatting Word documents in this live [ASP.NET Core Color Picker Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/colorpickercustomization#/tailwind3).
+

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-context-menu.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to Customize Context Menu in ASP.NET Core DOCX Editor | Syncfusion
-description: Customize the context menu in Syncfusion® React DOCX Editor by adding custom menu items, modifying existing options, and handling menu actions.
+description: Customize the context menu in Syncfusion® ASP .NET Core DOCX Editor by adding custom menu items, modifying existing options, and handling menu actions.
 platform: document-processing
 control: DOCX Editor
 documentation: ug

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-context-menu.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-context-menu.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Customize Context Menu in ASP.NET Core DOCX Editor | Syncfusion
 description: Customize the context menu in Syncfusion® React DOCX Editor by adding custom menu items, modifying existing options, and handling menu actions.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -30,7 +30,7 @@ documentation: ug
 
 ### Customize custom options in the context Menu
 
-The Document Editor allows you to customize the added custom option and also to hide or show the default context menu.
+The DOCX Editor allows you to customize the added custom option and also to hide or show the default context menu.
 
 #### Hide default context menu items
 
@@ -64,7 +64,7 @@ The following code shows how to hide or show the added custom option in the cont
 
 #### Customize context menu with sub-menu items
 
-The Document Editor allows you to customize the context menu with sub-menu items. You can achieve this by using the `addCustomMenu()` method.
+The DOCX Editor allows you to customize the context menu with sub-menu items. You can achieve this by using the `addCustomMenu()` method.
 
 The following code shows how to add sub-items to the custom option in the context menu in the Document Editor Container.
 
@@ -80,4 +80,4 @@ The following code shows how to add sub-items to the custom option in the contex
 
 ## Online demo
 
-Explore how to customize the context menu in the ASP.NET Core Document Editor for working with Word documents in this live [ASP.NET Core Context Menu Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/customcontextmenu#/tailwind3).
+Explore how to customize the context menu in the ASP.NET Core DOCX Editor for working with Word documents in this live [ASP.NET Core Context Menu Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/customcontextmenu#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-font-family-drop-down.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-font-family-drop-down.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Customize Font Family in ASP.NET Core DOCX Editor | Syncfusion
 description: Customize the font family drop down list in Syncfusion® ASP.NET Core DOCX Editor by configuring available font families and controlling font selection options.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -12,7 +12,7 @@ documentation: ug
 
 [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) provides options to customize the font family dropdown list using `fontFamilies` in `DocumentEditorSettings`. Fonts that are added in `fontFamilies` of `documentEditorSettings` will be displayed on the font dropdown list of the Text Properties pane and the Font dialog.
 
-Similarly, you can use the `documentEditorSettings` property for the Document Editor as well.
+Similarly, you can use the `documentEditorSettings` property for the DOCX Editor as well.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-ribbon.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-ribbon.md
@@ -22,7 +22,7 @@ Below are detailed examples for each ribbon customization scenario.
 
 ## File menu customization
 
-The Document Editor provides APIs to remove existing File menu items and add new custom items based on your requirements. You can modify the File menu using the `fileMenuItems` property.
+The DOCX Editor provides APIs to remove existing File menu items and add new custom items based on your requirements. You can modify the File menu using the `fileMenuItems` property.
 
 In the following code example, the `Open` and `Export` items have been removed from the File Menu Items, and new custom items have been added.
 
@@ -38,7 +38,7 @@ In the following code example, the `Open` and `Export` items have been removed f
 
 ## Backstage menu customization
 
-The Document Editor provides a `backStageMenu` API to add a backstage menu. When the backstage menu is enabled, the default File menu items are automatically hidden.
+The DOCX Editor provides a `backStageMenu` API to add a backstage menu. When the backstage menu is enabled, the default File menu items are automatically hidden.
 
 The following code example shows how to add the backstage menu items.
 
@@ -56,11 +56,11 @@ Refer to this documentation to know more about [`backstage items`](https://ej2.s
 
 ## Tab customization
 
-You can customize the ribbon tabs in the Document Editor by showing, hiding, or adding tabs according to your application's requirements.
+You can customize the ribbon tabs in the DOCX Editor by showing, hiding, or adding tabs according to your application's requirements.
 
 ### Show/Hide tab
 
-The Document Editor provides the `showTab` API to show and hide the existing tab using the existing `RibbonTabType` and `tabId`.
+The DOCX Editor provides the `showTab` API to show and hide the existing tab using the existing `RibbonTabType` and `tabId`.
 
 The following code example shows how to show or hide an existing tab using the existing tab type and tab id.
 
@@ -75,7 +75,7 @@ container.ribbon.showTab('custom_tab', false);
 
 ### Add tab
 
-The Document Editor provides the `addTab` API, which allows you to insert a new custom tab either between existing tabs or at the end of the ribbon tabs.
+The DOCX Editor provides the `addTab` API, which allows you to insert a new custom tab either between existing tabs or at the end of the ribbon tabs.
 
 ```typescript
 
@@ -120,7 +120,7 @@ You can also customize ribbon groups within a tab to better organize commands or
 
 ### Show/Hide group
 
-The Document Editor provides a `showGroup` API to show or hide existing groups within a ribbon tab.
+The DOCX Editor provides a `showGroup` API to show or hide existing groups within a ribbon tab.
 
 The following code example shows how to show or hide a group using the group Id or `RibbonGroupInfo`.
 
@@ -181,7 +181,7 @@ You can customize individual items within ribbon groups. This includes showing, 
 
 ### Show/Hide item
 
-Using the `showItems` API in the Document Editor ribbon, you can show or hide the existing item. Here, you can specify the item Id or `RibbonItemInfo`.
+Using the `showItems` API in the DOCX Editor ribbon, you can show or hide the existing item. Here, you can specify the item Id or `RibbonItemInfo`.
 
 The following code example shows how to show or hide an item using the item Id or `RibbonItemInfo`.
 
@@ -198,7 +198,7 @@ container.ribbon.showItems('custom_item', false);
 
 ### Enable/Disable item
 
-Using the `enableItems` API in the Document Editor ribbon, you can enable or disable the existing item.
+Using the `enableItems` API in the DOCX Editor ribbon, you can enable or disable the existing item.
 
 ```typescript
 // To disable the underline using ribbon item info
@@ -214,7 +214,7 @@ container.ribbon.enableItems('custom_item', false);
 
 ### Add item
 
-You can use the `addItem` API in the Document Editor ribbon to add a new item. Additionally, you can specify the target tab and group where the new item should be placed.
+You can use the `addItem` API in the DOCX Editor ribbon to add a new item. Additionally, you can specify the target tab and group where the new item should be placed.
 
 ```typescript
 
@@ -248,7 +248,7 @@ You can use the `addItem` API in the Document Editor ribbon to add a new item. A
 
 ## Online demo
 
-Explore how to customize the ribbon in the ASP.NET Core Document Editor for working with Word documents in this live [ASP.NET Core Ribbon Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/ribboncustomization#/tailwind3).
+Explore how to customize the ribbon in the ASP.NET Core DOCX Editor for working with Word documents in this live [ASP.NET Core Ribbon Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/ribboncustomization#/tailwind3).
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-tool-bar.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/customize-tool-bar.md
@@ -3,14 +3,14 @@ layout: post
 title: How to Customize Toolbar in ASP.NET Core DOCX Editor | Syncfusion
 description: Customize the toolbar in Syncfusion® ASP.NET Core DOCX Editor by adding, removing, showing, hiding, enabling, and disabling toolbar items.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 
 # How to Customize Toolbar in ASP.NET Core DOCX Editor
 
-## How to customize the existing toolbar in ASP.NET Core Document Editor Container
+## How to customize the existing toolbar in ASP.NET Core DOCX Editor Container
 
 [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) Container allows you to customize (add, show, hide, enable, and disable) existing items in a toolbar.
 
@@ -34,4 +34,4 @@ N> The default value of `ToolbarItems` is `['New', 'Open', 'Separator', 'Undo', 
 
 ## Online demo
 
-Explore how to customize the toolbar in the ASP.NET Core Document Editor for working with Word documents in this live [ASP.NET Core Toolbar Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/toolbarcustomization#/tailwind3).
+Explore how to customize the toolbar in the ASP.NET Core DOCX Editor for working with Word documents in this live [ASP.NET Core Toolbar Customization demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/toolbarcustomization#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/deploy-document-editor-component-for-mobile.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/deploy-document-editor-component-for-mobile.md
@@ -3,15 +3,15 @@ layout: post
 title: How to Deploy ASP.NET Core DOCX Editor for Mobile | Syncfusion
 description: Deploy the Syncfusion® ASP.NET Core DOCX Editor for mobile browsers in read-only mode to provide an optimized document viewing experience on mobile devices.
 platform: document-processing
-control: Deploy the Document Editor component for mobile
+control: Deploy the DOCX Editor component for mobile
 documentation: ug
 ---
 
 # How to Deploy ASP.NET Core DOCX Editor for Mobile
 
-## Document Editor component for mobile
+## DOCX Editor component for mobile
 
-At present, the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component is not responsive on mobile, and the editing functionalities are not ensured in mobile browsers. However, it works properly as a document viewer in mobile browsers. Hence, it is recommended to switch the Document Editor component to read-only mode in mobile browsers. Also, invoke the `fitPage` method with the `FitPageWidth` parameter in the document change event to display one full page by adjusting the zoom factor.
+At present, the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component is not responsive on mobile, and the editing functionalities are not ensured in mobile browsers. However, it works properly as a document viewer in mobile browsers. Hence, it is recommended to switch the DOCX Editor component to read-only mode in mobile browsers. Also, invoke the `fitPage` method with the `FitPageWidth` parameter in the document change event to display one full page by adjusting the zoom factor.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-header-and-footer-edit-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-header-and-footer-edit-in-document-editor.md
@@ -42,7 +42,7 @@ The following example code illustrates how to close header and footer when the s
 
 ## Disable header and footer edit in DocumentEditor instance
 
-Like restrictEditing, you can use the [`isReadOnly`] property in the Document Editor to disable header and footer edit.
+Like restrictEditing, you can use the [`isReadOnly`] property in the DOCX Editor to disable header and footer edit.
 
 The following example code illustrates how to disable header and footer edit in the `DocumentEditor` instance.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/disable-optimized-text-measuring.md
@@ -10,9 +10,9 @@ documentation: ug
 
 # How to Disable Optimized Text Measuring in ASP.NET Core DOCX Editor
 
-Starting from v19.3.0.x, the accuracy of text size measurements in the Document Editor is improved to match Microsoft Word pagination for most Word documents. This improvement is included as the default behavior along with an optional API `enableOptimizedTextMeasuring` in the Document Editor settings.
+Starting from v19.3.0.x, the accuracy of text size measurements in the DOCX Editor is improved to match Microsoft Word pagination for most Word documents. This improvement is included as the default behavior along with an optional API `enableOptimizedTextMeasuring` in the Document Editor settings.
 
-If you want the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions, then you can disable this optimized text measuring improvement by setting the `enableOptimizedTextMeasuring` property of the Document Editor component to `false`.
+If you want the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions, then you can disable this optimized text measuring improvement by setting the `enableOptimizedTextMeasuring` property of the DOCX Editor component to `false`.
 
 ## Disable optimized text measuring in `DocumentEditorContainer` instance
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/enable-ruler-in-document-editor-component.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/enable-ruler-in-document-editor-component.md
@@ -9,11 +9,11 @@ documentation: ug
 
 # How to Enable Ruler in ASP.NET Core DOCX Editor
 
-## Enable ruler in Document Editor
+## Enable ruler in DOCX Editor
 
 Using the ruler, you can set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
-The following example illustrates how to enable the ruler in the Document Editor.
+The following example illustrates how to enable the ruler in the DOCX Editor.
 
 
 {% tabs %}
@@ -27,7 +27,7 @@ The following example illustrates how to enable the ruler in the Document Editor
 
 
 
-## Enable ruler in Document Editor Container
+## Enable ruler in DOCX Editor Container
 
 Using the ruler, you can set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the Document Editor Container.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-current-word.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-current-word.md
@@ -13,7 +13,7 @@ You can get the current word or paragraph content from the [ASP.NET Core DOCX Ed
 
 ## Select and get the word in current cursor position
 
-You can use the [`selectCurrentWord`] API in the selection module to select the current word at the cursor position and use the [`text`] API to get the selected content as plain text from the Document Editor component.
+You can use the [`selectCurrentWord`] API in the selection module to select the current word at the cursor position and use the [`text`] API to get the selected content as plain text from the DOCX Editor component.
 
 The following example code illustrates how to select and get the current word as plain text.
 
@@ -30,7 +30,7 @@ The following example code illustrates how to select and get the current word as
 
 ## Select and get the paragraph in current cursor position
 
-You can use the [`selectParagraph`] API in the selection module to select the current paragraph at the cursor position and use the [`text`] API or the [`sfdt`] API to get the selected content as plain text or SFDT from the Document Editor component.
+You can use the [`selectParagraph`] API in the selection module to select the current paragraph at the cursor position and use the [`text`] API or the [`sfdt`] API to get the selected content as plain text or SFDT from the DOCX Editor component.
 
 The following example code illustrates how to select and get the current paragraph as SFDT.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-the-selected-content.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/get-the-selected-content.md
@@ -14,7 +14,7 @@ You can get the selected content from the [ASP.NET Core DOCX Editor](https://www
 
 ## Get the selected content as plain text
 
-You can use the `text` API to get the selected content as plain text from the ASP.NET Core Document Editor component.
+You can use the `text` API to get the selected content as plain text from the ASP.NET Core DOCX Editor component.
 
 
 {% tabs %}
@@ -34,7 +34,7 @@ You can add the following custom options using this API:
 
 ## Get the selected content as SFDT (rich text)
 
-You can use the `sfdt` API to get the selected content as rich text from the ASP.NET Core Document Editor component.
+You can use the `sfdt` API to get the selected content as rich text from the ASP.NET Core DOCX Editor component.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-page-number-and-navigate-to-page.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/insert-page-number-and-navigate-to-page.md
@@ -15,7 +15,7 @@ You can insert a page number and navigate to a specific page in the [ASP.NET Cor
 
 You can use the [`insertPageNumber`] API in the editor module to insert the page number at the current cursor position. By default, the page number will be inserted in Arabic number style. You can change it by providing the number style in the parameter.
 
-N> Currently, the Document Editor has options to insert a page number at the current cursor position.
+N> Currently, the DOCX Editor has options to insert a page number at the current cursor position.
 
 The following example code illustrates how to insert a page number in the header.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-default-document.md
@@ -10,11 +10,11 @@ documentation: ug
 
 # How to Open a Default Document in ASP.NET Core DOCX Editor
 
-This section explains how to open a default document when the Document Editor and Document Editor Container are initialized.
+This section explains how to open a default document when the DOCX Editor and Document Editor Container are initialized.
 
-## Opening a default document in the Document Editor
+## Opening a default document in the DOCX Editor
 
-Using the `open` method in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) allows you to open the document in SFDT format. To open the document by default, call the `open` method in the `created` event of the Document Editor, which is triggered once the control is created.
+Using the `open` method in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) allows you to open the document in SFDT format. To open the document by default, call the `open` method in the `created` event of the DOCX Editor, which is triggered once the control is created.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/open-document-by-address.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # How to Open a Document by URL in ASP.NET Core DOCX Editor
 
-## Open a document from a URL in the Document Editor
+## Open a document from a URL in the DOCX Editor
 
 This article explains how to open a document from a URL in the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/override-the-keyboard-shortcuts.md
@@ -14,7 +14,7 @@ The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-ne
 
 ## Preventing the default keyboard shortcut
 
-The following code shows how to prevent the `Ctrl + C` keyboard shortcut for copying selected content in the Document Editor.
+The following code shows how to prevent the `Ctrl + C` keyboard shortcut for copying selected content in the DOCX Editor.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/read-by-default.md
@@ -10,11 +10,11 @@ documentation: ug
 
 # How to Open ASP.NET Core DOCX Editor in Read-Only Mode
 
-This section explains how to open a document in read only mode by default in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor and Document Editor Container).
+This section explains how to open a document in read only mode by default in [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (DOCX Editor and Document Editor Container).
 
-## Opening a document in read only mode by default in Document Editor
+## Opening a document in read only mode by default in DOCX Editor
 
-Using the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) property in the Document Editor allows you to enable or disable read only mode in the document editor.
+Using the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) property in the DOCX Editor allows you to enable or disable read only mode in the DOCX Editor.
 
 
 {% tabs %}
@@ -28,7 +28,7 @@ Using the [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusio
 
 ## Opening a document in read only mode by default in Document Editor Container
 
-Using the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) property in the Document Editor Container allows you to enable or disable read only mode in the document editor.
+Using the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) property in the Document Editor Container allows you to enable or disable read only mode in the DOCX Editor.
 
 
 {% tabs %}
@@ -40,4 +40,4 @@ Using the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Sync
 {% endtabs %}
 
 
-N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in [`Document Editor Container`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html) and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in [`Document Editor`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html) based on your requirement to change component to read only mode.
+N> You can use the [`restrictEditing`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html#Syncfusion_EJ2_DocumentEditor_DocumentEditorContainer_RestrictEditing) in [`Document Editor Container`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditorContainer.html) and [`isReadOnly`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_IsReadOnly) in [`DOCX Editor`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html) based on your requirement to change component to read only mode.

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/resize-document-editor.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Resize in ASP.NET Core DOCX Editor | Syncfusion
 description: Adjust the height and width of the Syncfusion® ASP.NET Core DOCX Editor to create responsive layouts and customize the document editing experience.
 platform: document-processing
-control: Resize Document Editor
+control: Resize DOCX Editor
 documentation: ug
 ---
 
@@ -12,9 +12,9 @@ documentation: ug
 
 This section explains how to change height and width of [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor).
 
-## Change height of Document Editor
+## Change height of DOCX Editor
 
-DocumentEditorContainer initially renders with a default height. You can change the height of the Document Editor using the `height` property, the value of which is in pixels.
+DocumentEditorContainer initially renders with a default height. You can change the height of the DOCX Editor using the `height` property, the value of which is in pixels.
 
 
 {% tabs %}
@@ -29,9 +29,9 @@ DocumentEditorContainer initially renders with a default height. You can change 
 
 Similarly, you can use the `height` property for DocumentEditor also.
 
-## Change width of Document Editor
+## Change width of DOCX Editor
 
-DocumentEditorContainer initially renders with a default width. You can change the width of the Document Editor using the `width` property, the value of which is in percent.
+DocumentEditorContainer initially renders with a default width. You can change the width of the DOCX Editor using the `width` property, the value of which is in percent.
 
 
 
@@ -47,9 +47,9 @@ DocumentEditorContainer initially renders with a default width. You can change t
 
 Similarly, you can use the `width` property for DocumentEditor also.
 
-## Resize Document Editor
+## Resize DOCX Editor
 
-Using the `resize` method, you can change the height and width of the Document Editor.
+Using the `resize` method, you can change the height and width of the DOCX Editor.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/retrieve-the-bookmark-content-as-text.md
@@ -13,7 +13,7 @@ You can get the bookmark or whole document content from the [ASP.NET Core DOCX E
 
 ## Get the bookmark content as plain text
 
-You can use the [`selectBookmark`] API to navigate to the bookmark and use the [`text`] API to get the bookmark content as plain text from the Document Editor component.
+You can use the [`selectBookmark`] API to navigate to the bookmark and use the [`text`] API to get the bookmark content as plain text from the DOCX Editor component.
 
 The following example code illustrates how to get the bookmark content as plain text.
 
@@ -31,7 +31,7 @@ To get the bookmark content as SFDT (rich text), check this [`link`](../../asp-n
 
 ## Get the whole document content as text
 
-You can use the [`text`] API to get the whole document content as plain text from the Document Editor component.
+You can use the [`text`] API to get the whole document content as plain text from the DOCX Editor component.
 
 The following example code illustrates how to get the whole document content as plain text.
 
@@ -47,7 +47,7 @@ The following example code illustrates how to get the whole document content as 
 
 ## Get the whole document content as SFDT (rich text)
 
-You can use the [`serialize`] API to get the whole document content as an SFDT string from the Document Editor component.
+You can use the [`serialize`] API to get the whole document content as an SFDT string from the DOCX Editor component.
 
 The following example code illustrates how to get the whole document content as SFDT.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/how-to/set-default-format-in-document-editor.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Set Default Format in ASP.NET Core DOCX Editor | Syncfusion
 description: Set default character, paragraph, and section formatting in Syncfusion® ASP.NET Core DOCX Editor for consistent document styling across documents.
 platform: document-processing
-control: Set Default Format In Document Editor
+control: Set Default Format In DOCX Editor
 documentation: ug
 ---
 
@@ -14,7 +14,7 @@ You can set the default character format, paragraph format and section format in
 
 ## Set the default character format
 
-You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the Document Editor default font size is 11 and you can change it to any valid value.
+You can use the `setDefaultCharacterFormat` method to set the default character format. For example, the DOCX Editor default font size is 11 and you can change it to any valid value.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/image.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/image.md
@@ -26,20 +26,20 @@ Image files will be internally converted to base64 string. Whereas, online image
 
 ## Image resizing
 
-Document Editor provides a built-in image resizer that can be injected into your application based on the requirements. This allows you to resize the image by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
+DOCX Editor provides a built-in image resizer that can be injected into your application based on the requirements. This allows you to resize the image by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
 
 ![Image](images/image.JPG)
 
 ## Changing size
 
-Document Editor exposes an API to get or set the size of the selected image. Refer to the following sample code.
+DOCX Editor exposes an API to get or set the size of the selected image. Refer to the following sample code.
 
 ```typescript
 documenteditor.selection.imageFormat.width = 800;
 documenteditor.selection.imageFormat.height = 800;
 ```
 
-N> Images are stored and processed (read/write) as a base64 string in Document Editor. The online image URL is preserved as a URL in Document Editor upon saving.
+N> Images are stored and processed (read/write) as a base64 string in DOCX Editor. The online image URL is preserved as a URL in DOCX Editor upon saving.
 
 ## Text wrapping style
 
@@ -47,7 +47,7 @@ Text wrapping refers to how images fit with surrounding text in a document. Plea
 
 ## Positioning the image
 
-Document Editor preserves the position properties of the image and displays the image based on those position properties. It does not support modifying the position properties. Whereas, the image will be automatically moved along with the text being edited if it is positioned relative to the line or paragraph.
+DOCX Editor preserves the position properties of the image and displays the image based on those position properties. It does not support modifying the position properties. Whereas, the image will be automatically moved along with the text being edited if it is positioned relative to the line or paragraph.
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/link.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/link.md
@@ -14,7 +14,7 @@ documentation: ug
 
 ## Navigate a hyperlink
 
-Document Editor triggers `requestNavigate` event whenever the user clicks the Ctrl key or taps a hyperlink within the document. This event provides necessary details about link type, navigation URL, and local URL (if any) as arguments, and allows you to easily customize the hyperlink navigation functionality.
+DOCX Editor triggers `requestNavigate` event whenever the user clicks the Ctrl key or taps a hyperlink within the document. This event provides necessary details about link type, navigation URL, and local URL (if any) as arguments, and allows you to easily customize the hyperlink navigation functionality.
 
 ### Add the requestNavigate event for DocumentEditor
 
@@ -54,7 +54,7 @@ documenteditor.selection.navigateHyperlink();
 
 ## Copy link
 
-Document Editor copies link text of a hyperlink field to the clipboard if the selection is in a hyperlink.
+DOCX Editor copies link text of a hyperlink field to the clipboard if the selection is in a hyperlink.
 
 ```typescript
 documenteditor.selection.copyHyperlink();
@@ -62,7 +62,7 @@ documenteditor.selection.copyHyperlink();
 
 ## Add hyperlink
 
-To create a basic hyperlink in the document, press `ENTER` / `SPACEBAR` / `SHIFT + ENTER` / `TAB` key after typing the address, for instance `http://www.google.com`. Document Editor automatically converts this address to a hyperlink field. The text can be considered as a valid URL if it starts with any of the following.
+To create a basic hyperlink in the document, press `ENTER` / `SPACEBAR` / `SHIFT + ENTER` / `TAB` key after typing the address, for instance `http://www.google.com`. DOCX Editor automatically converts this address to a hyperlink field. The text can be considered as a valid URL if it starts with any of the following.
 
 N> `<http://>`
 N> `<https://>`
@@ -103,7 +103,7 @@ documenteditor.editor.removeHyperlink();
 
 ## Hyperlink dialog
 
-Document Editor provides dialog support to insert or edit a hyperlink.
+DOCX Editor provides dialog support to insert or edit a hyperlink.
 
 
 {% tabs %}
@@ -124,7 +124,7 @@ You can use the following keyboard shortcut to open the hyperlink dialog if the 
 
 ## Online Demo
 
-Explore how to insert and manage hyperlinks in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/hyperlinksandbookmarks#/tailwind3).
+Explore how to insert and manage hyperlinks in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/hyperlinksandbookmarks#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/list-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/list-format.md
@@ -65,13 +65,13 @@ documenteditor.editor.clearList();
 
 ## Editing numbered list
 
-Document Editor restarts the numbering or continues numbering for a numbered list. These options are found in the built-in context menu, if the list value is selected.
+DOCX Editor restarts the numbering or continues numbering for a numbered list. These options are found in the built-in context menu, if the list value is selected.
 
 ![Image](images/list.JPG)
 
 ## Online Demo
 
-Explore how to apply bullets and numbering in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/bulletsandnumbering#/tailwind3).
+Explore how to apply bullets and numbering in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/bulletsandnumbering#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/notes.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/notes.md
@@ -18,7 +18,7 @@ The footnotes and endnotes are both ways of adding extra bits of information to 
 
 ## Insert footnotes
 
-The Document Editor exposes an API to insert footnotes at the cursor position programmatically or at the end of the selected text.
+The DOCX Editor exposes an API to insert footnotes at the cursor position programmatically or at the end of the selected text.
 
 
 {% tabs %}
@@ -33,7 +33,7 @@ The Document Editor exposes an API to insert footnotes at the cursor position pr
 
 ## Insert endnotes
 
-The Document Editor exposes an API to insert endnotes at the cursor position programmatically or at the end of the selected text.
+The DOCX Editor exposes an API to insert endnotes at the cursor position programmatically or at the end of the selected text.
 
 
 {% tabs %}
@@ -54,4 +54,4 @@ You can update or edit the footnotes and endnotes using the built-in context men
 
 ## Online Demo
 
-Explore how to add and manage notes in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/notes#/tailwind3).
+Explore how to add and manage notes in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/notes#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/aws-s3-bucket.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/aws-s3-bucket.md
@@ -13,9 +13,9 @@ domainurl: ##DomainURL##
 To load a document from AWS S3 in a [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor), you can follow the steps below.
 
 
-**Step 1:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 1:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 
@@ -109,7 +109,7 @@ public async Task<string> LoadFromS3([FromBody] Dictionary<string, string> onObj
 
 N> Replace **Your Access Key from AWS S3**, **Your Secret Key from AWS S3**, and **Your Bucket name from AWS S3** with your actual AWS access key, secret key, and bucket name.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/azure-blob-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/azure-blob-storage.md
@@ -13,9 +13,9 @@ domainurl: ##DomainURL##
 To load document from Azure Blob Storage in a [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor), you can follow the steps below.
 
 
-**Step 1:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 1:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 2:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -94,7 +94,7 @@ public IActionResult LoadFromAzure([FromBody] Dictionary<string, string> jsonObj
 
 N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, and **Your container name in Azure** with the actual container name.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/box-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/box-cloud-file-storage.md
@@ -17,9 +17,9 @@ To load a document from Box cloud file storage in a [ASP.NET Core DOCX Editor](h
 To access Box storage programmatically, a Box developer account is required. Go to the [Box Developer Console](https://developer.box.com/guides), sign in or create a new account, and then create a new Box application. This application provides the necessary credentials — Client ID and Client Secret — to authenticate and access Box APIs. Before accessing files, the application must be authenticated to access your Box account. Box uses OAuth 2.0 for authentication.
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -120,7 +120,7 @@ public async Task<string> LoadFromBoxCloud([FromBody] Dictionary<string, string>
 
 N> Replace **Your_Box_Storage_Access_Token** with your actual Box access token, and **Your_Folder_ID** with the ID of the folder in your Box storage where you want to perform specific operations. Remember to use your valid Box API credentials, as **Your_Box_Storage_ClientID** and **Your_Box_Storage_ClientSecret** are placeholders for your application's API key and secret, respectively.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/dropbox-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/dropbox-cloud-file-storage.md
@@ -17,9 +17,9 @@ To load a document from Dropbox cloud file storage in a [ASP.NET Core DOCX Edito
 To create a Dropbox app, follow the official documentation provided by Dropbox [link](https://www.dropbox.com/developers/documentation/dotnet#tutorial). The process involves visiting the Dropbox Developer website and using their App Console to set up your API app. This app enables programmatic access to Dropbox files and data.
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -106,7 +106,7 @@ public async Task<string> LoadFromDropBox([FromBody] Dictionary<string, string> 
 
 N> Replace **Your_Dropbox_Access_Token** with your actual Dropbox access token, and **Your_Folder_Name** with your folder name.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/google-cloud-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/google-cloud-storage.md
@@ -13,9 +13,9 @@ domainurl: ##DomainURL##
 To load a document from Google Cloud Storage in a [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor), you can follow the steps below.
 
 
-**Step 1:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 1:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 2:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -109,7 +109,7 @@ N> Replace **Your Bucket name from Google Cloud Storage** with the actual name o
 
 N> Replace **path/to/service-account-key.json** with the actual file path to your service account key JSON file. Make sure to provide the correct path and filename.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/google-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/google-drive.md
@@ -17,9 +17,9 @@ To load a document from Google Drive in a [ASP.NET Core DOCX Editor](https://www
 You must set up a project in the Google Developers Console and enable the Google Drive API. Obtain the necessary credentials to access the API. For more information, see the official [documentation](https://developers.google.com/drive/api/guides/enable-sdk).
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -134,7 +134,7 @@ N> Replace **Your Google Drive Folder ID**, **Your Application name**, and **You
 
 N> The **FolderId** part is the unique identifier for the folder. For example, if your folder URL is: `https://drive.google.com/drive/folders/abc123xyz456`, then the folder ID is `abc123xyz456`.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/one-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/opening-documents/one-drive.md
@@ -17,9 +17,9 @@ To load a document from OneDrive in a [ASP.NET Core DOCX Editor](https://www.syn
 Create a Microsoft Graph API application and obtain the necessary credentials, namely the application ID and tenant ID. Follow the steps provided in this [link](https://learn.microsoft.com/en-us/training/modules/msgraph-access-file-data/3-exercise-access-files-onedrive) to create the application and obtain the required IDs. 
 
 
-**Step 2:** Create a simple Document Editor sample in ASP.NET Core
+**Step 2:** Create a simple DOCX Editor sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -131,7 +131,7 @@ public async Task<string> LoadFromOneDrive([FromBody] Dictionary<string, string>
 
 N> Replace **Your_Tenant_ID**, **Your_Application_ID**, and **Your_Folder_Name_To_Access_The_Files_In_OneDrive** with your actual tenant ID, application ID, and folder name.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, the document returned from the web service is opened using the `open` method.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/overview.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/overview.md
@@ -12,7 +12,7 @@ documentation: ug
 
 The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) is a feature-rich, user-interactive component that enables creating, editing, viewing, and printing Word documents with advanced formatting, editing capabilities, and broad support for document import and export formats.
 
-![Output of ASP.NET Core Document Editor](./images/docx-editor.png)
+![Output of ASP.NET Core DOCX Editor](./images/docx-editor.png)
 
 ## Key Features
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/paragraph-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/paragraph-format.md
@@ -132,11 +132,11 @@ documenteditor.selection.paragraphFormat.borders.bottom.color = "#000000";
 
 ```
 
-N> Currently, the Document Editor component renders every border style as a single line. However, any border style you apply is preserved correctly when opening the exported Word document in Microsoft Word.
+N> Currently, the DOCX Editor component renders every border style as a single line. However, any border style you apply is preserved correctly when opening the exported Word document in Microsoft Word.
 
 ## Show or Hide Paragraph marks
 
-Use the following code to toggle the visibility of hidden formatting symbols like spaces, tabs, paragraph marks, and breaks in the Document Editor component. These marks indicate the start and end of a paragraph and reveal all hidden formatting symbols in a Word document.
+Use the following code to toggle the visibility of hidden formatting symbols like spaces, tabs, paragraph marks, and breaks in the DOCX Editor component. These marks indicate the start and end of a paragraph and reveal all hidden formatting symbols in a Word document.
 
 ```typescript
 documenteditor.documentEditorSettings.showHiddenMarks = true;
@@ -156,7 +156,7 @@ documenteditor.documentEditorSettings.showHiddenMarks = true;
 
 ## Online Demo
 
-Explore how to apply paragraph formatting in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/paragraphformat#/tailwind3).
+Explore how to apply paragraph formatting in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/paragraphformat#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/print.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/print.md
@@ -33,11 +33,11 @@ To print the document, use the `print` method from the [ASP.NET Core DOCX Editor
 {% endtabs %}
 
 
-N> To enable print for a document editor instance, set enablePrint as true.
+N> To enable print for a DOCX Editor instance, set enablePrint as true.
 
 ## Improve print quality
 
-The Document Editor provides an option to improve the print quality using `printDevicePixelRatio` in the Document Editor settings. The Document Editor uses a canvas approach to render content. The canvas is then converted to an image and processed for printing. Using the `printDevicePixelRatio` API, you can increase the image quality based on your requirements.
+The DOCX Editor provides an option to improve the print quality using `printDevicePixelRatio` in the Document Editor settings. The DOCX Editor uses a canvas approach to render content. The canvas is then converted to an image and processed for printing. Using the `printDevicePixelRatio` API, you can increase the image quality based on your requirements.
 
 
 {% tabs %}
@@ -54,7 +54,7 @@ N> By default, printDevicePixelRatio value is 1.
 
 ## Print using window object
 
-You can print the document in the Document Editor by passing the window instance. This is useful for implementing print in third-party frameworks such as Electron, where the window instance is not available.
+You can print the document in the DOCX Editor by passing the window instance. This is useful for implementing print in third-party frameworks such as Electron, where the window instance is not available.
 
 
 {% tabs %}
@@ -85,7 +85,7 @@ However, you can customize margins, paper, and layout options by modifying the s
 {% endtabs %}
 
 
-By customizing margins, paper, and layouts, the document layout will change in the Document Editor. To modify these options during the print operation, serialize the document as SFDT using the `serialize` method on a Document Editor instance and open the SFDT data in another Document Editor instance in a separate window.
+By customizing margins, paper, and layouts, the document layout will change in the DOCX Editor. To modify these options during the print operation, serialize the document as SFDT using the `serialize` method on a DOCX Editor instance and open the SFDT data in another DOCX Editor instance in a separate window.
 
 
 {% tabs %}
@@ -99,7 +99,7 @@ By customizing margins, paper, and layouts, the document layout will change in t
 
 ## Online Demo
 
-Explore how to print Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/print#/tailwind3).
+Explore how to print Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/print#/tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/restrict-editing.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/restrict-editing.md
@@ -84,7 +84,7 @@ The Restrict Editing Pane provides the following options to manage the document:
 
 ## Online Demo
 
-Explore how to restrict editing and protect Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/documentprotection#tailwind3).
+Explore how to restrict editing and protect Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/documentprotection#tailwind3).
 
 ## See Also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/ribbon.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/ribbon.md
@@ -16,14 +16,14 @@ You can switch between the **Toolbar** and **Ribbon** UI, and choose between **C
 
 ## Enable Ribbon Mode
 
-To enable the `Ribbon` in the Document Editor, use the `toolbarMode` property of `DocumentEditorContainer`. The available toolbar modes are:
+To enable the `Ribbon` in the DOCX Editor, use the `toolbarMode` property of `DocumentEditorContainer`. The available toolbar modes are:
 
 - **`'Toolbar'`** - The traditional toolbar UI.
 - **`'Ribbon'`** - The Ribbon UI, which provides a tabbed interface with grouped commands.
 
 By default, `toolbarMode` is `Toolbar`.
 
-The following example shows how to enable the `Ribbon` in the Document Editor.
+The following example shows how to enable the `Ribbon` in the DOCX Editor.
 
 ```typescript
 
@@ -35,14 +35,14 @@ The following example shows how to enable the `Ribbon` in the Document Editor.
 
 ## Ribbon Layouts
 
-The Document Editor provides two different Ribbon layouts:
+The DOCX Editor provides two different Ribbon layouts:
 
 - **Classic**: A traditional, Office-like ribbon with detailed grouping and larger icons.
 - **Simplified**: A more compact ribbon design with streamlined controls.
 
 By default, `ribbonLayout` is set to `Simplified`.
 
-The following example shows how to configure the ribbon layout in the Document Editor:
+The following example shows how to configure the ribbon layout in the DOCX Editor:
 
 ```typescript
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/aws-s3-bucket.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/aws-s3-bucket.md
@@ -15,7 +15,7 @@ To save a document to AWS S3, follow these steps:
 
 **Step 1:** Create a Simple [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 2:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -118,7 +118,7 @@ private string GetValue(IFormCollection data, string key)
 
 N> Replace **Your Access Key from AWS S3**, **Your Secret Key from AWS S3**, and **Your Bucket name from AWS S3** with your actual AWS access key, secret key, and bucket name.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in the AWS S3 bucket.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/azure-blob-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/azure-blob-storage.md
@@ -15,7 +15,7 @@ To save a document to Azure Blob Storage, follow these steps:
 
 **Step 1:** Create a Simple [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 2:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -98,7 +98,7 @@ public void SaveToAzure(IFormCollection data)
 
 N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, and **Your container name in Azure** with the actual container name.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in the Azure Blob Storage container.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/box-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/box-cloud-file-storage.md
@@ -17,9 +17,9 @@ To save a document to Box cloud file storage, follow these steps:
 To access Box storage programmatically, you'll need a developer account with Box. Go to the [Box Developer Console](https://developer.box.com/guides), sign in or create a new account, and then create a new Box application. This application will provide you with the necessary credentials Client ID and Client Secret to authenticate and access Box APIs. Before accessing files, you need to authenticate your application to access your Box account. Box API supports OAuth 2.0 authentication for this purpose.
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -133,7 +133,7 @@ private string GetValue(IFormCollection data, string key)
 
 N> Replace **Your_Box_Storage_Access_Token** with your actual Box access token, and **Your_Folder_ID** with the ID of the folder in your Box storage where you want to perform specific operations. Remember to use your valid Box API credentials, as **Your_Box_Storage_ClientID** and **Your_Box_Storage_ClientSecret** are placeholders for your application's API key and secret.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in Box cloud file storage.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/dropbox-cloud-file-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/dropbox-cloud-file-storage.md
@@ -17,9 +17,9 @@ To save a document to Dropbox cloud file storage, follow these steps:
 To create a Dropbox API app, follow the official [Dropbox .NET tutorial](https://www.dropbox.com/developers/documentation/dotnet#tutorial). The process involves visiting the Dropbox Developer website and using their App Console to set up your API app. This app will allow you to interact with Dropbox programmatically, enabling secure access to files and data.
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -128,7 +128,7 @@ private string GetValue(IFormCollection data, string key)
 
 N> Replace **Your_Dropbox_Access_Token** with your actual Dropbox access token and **Your_Folder_Name** with your folder name.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in Dropbox cloud file storage.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/google-cloud-storage.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/google-cloud-storage.md
@@ -14,7 +14,7 @@ To save a document to Google Cloud Storage, follow these steps:
 
 **Step 1:** Create a Simple [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 2:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -132,7 +132,7 @@ N>
 1. Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket.
 2. Replace **path/to/service-account-key.json** with the actual file path to your service account key JSON file. Make sure to provide the correct path and filename.
 
-**Step 3:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 3:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in Google Cloud Storage.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/google-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/google-drive.md
@@ -17,9 +17,9 @@ To save a document to Google Drive, follow these steps:
 You must set up a project in the Google Developers Console and enable the Google Drive API. Obtain the necessary credentials to access the API. For more information, refer to the official [Enable the Drive API](https://developers.google.com/drive/api/guides/enable-sdk) guide.
 
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component.
+Follow the steps in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component.
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -152,7 +152,7 @@ N> The **FolderId** is the unique identifier for the folder. For example, if you
 
 N> The JSON file (`credentials.json`) downloaded from the Google Cloud Console contains your OAuth 2.0 **Client ID** and **Client Secret**. Use these credentials to interface your application with the Google Drive API.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in Google Drive.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/one-drive.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/saving-documents/one-drive.md
@@ -16,9 +16,9 @@ To save a document to OneDrive, follow these steps:
 
 Create a Microsoft Graph API application and obtain the application ID and tenant ID. Follow the steps provided in the [Microsoft Graph training](https://learn.microsoft.com/en-us/training/modules/msgraph-access-file-data/3-exercise-access-files-onedrive) to create the application and obtain the required IDs.
 
-**Step 2:** Create a Simple Document Editor Sample in ASP.NET Core
+**Step 2:** Create a Simple DOCX Editor Sample in ASP.NET Core
 
-Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple Document Editor sample in ASP.NET Core. This will give you a basic setup of the Document Editor component. 
+Start by following the steps provided in this [link](../../document-editor/getting-started-core) to create a simple DOCX Editor sample in ASP.NET Core. This will give you a basic setup of the DOCX Editor component. 
 
 
 **Step 3:** Modify the `DocumentEditorController.cs` File in the Web Service Project
@@ -134,7 +134,7 @@ private string GetValue(IFormCollection data, string key)
 
 N> Replace **Your_Tenant_ID**, **Your_Application_ID**, and **Your_Folder_Name_To_Access_The_Files_In_OneDrive** with your actual tenant ID, application ID, and folder name.
 
-**Step 4:**  Modify the Index.cshtml File in the Document Editor sample
+**Step 4:**  Modify the Index.cshtml File in the DOCX Editor sample
 
 On the client side, export the document to a blob using `saveAsBlob` and send it to the server for saving in OneDrive.
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/scrolling-zooming.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/scrolling-zooming.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # Scrolling and Zooming in ASP.NET Core DOCX Editor
 
-The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) renders the document page by page. You can scroll through the pages by mouse wheel or touch interactions. You can also scroll to a specific page by using the [`scrollToPage()`] method of the Document Editor instance.
+The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) renders the document page by page. You can scroll through the pages by mouse wheel or touch interactions. You can also scroll to a specific page by using the [`scrollToPage()`] method of the DOCX Editor instance.
 
 
 {% tabs %}
@@ -25,7 +25,7 @@ The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-ne
 
 N> Calling this method brings the specified page into view but doesn’t move the selection. This method works even if selection is not enabled.
 
-To move the selection to a specific page in the Document Editor and bring it into view, you can use the [`goToPage()`] method of the selection instance.
+To move the selection to a specific page in the DOCX Editor and bring it into view, you can use the [`goToPage()`] method of the selection instance.
 
 
 {% tabs %}
@@ -41,7 +41,7 @@ To move the selection to a specific page in the Document Editor and bring it int
 
 ## Zooming
 
-You can scale the contents in the Document Editor from 10% to 500% of the actual size. You can achieve this using mouse or touch interactions. You can also use the [`zoomFactor`] property of the Document Editor instance. The value ranges from 0.1 to 5 (10% to 500%).
+You can scale the contents in the DOCX Editor from 10% to 500% of the actual size. You can achieve this using mouse or touch interactions. You can also use the [`zoomFactor`] property of the DOCX Editor instance. The value ranges from 0.1 to 5 (10% to 500%).
 
 
 {% tabs %}
@@ -55,7 +55,7 @@ You can scale the contents in the Document Editor from 10% to 500% of the actual
 
 ## Page fit
 
-Apart from specifying the zoom factor as a value, the Document Editor provides an option to specify page fit options such as fit to full page or fit to page width. You can set this option using the [`fitPage()`] method of the Document Editor instance.
+Apart from specifying the zoom factor as a value, the DOCX Editor provides an option to specify page fit options such as fit to full page or fit to page width. You can set this option using the [`fitPage()`] method of the DOCX Editor instance.
 
 
 {% tabs %}

--- a/Document-Processing/Word/Word-Processor/asp-net-core/section-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/section-format.md
@@ -34,7 +34,7 @@ documenteditor.selection.sectionFormat.bottomMargin = 10;
 documenteditor.selection.sectionFormat.topMargin = 10;
 ```
 
-N> The maximum value of `Margin` is 1584, as per the Microsoft Word application, and you can set any value less than or equal to 1584 to this property. If you set any value greater than 1584, then the Syncfusion Document Editor will automatically reset it to 1584.
+N> The maximum value of `Margin` is 1584, as per the Microsoft Word application, and you can set any value less than or equal to 1584 to this property. If you set any value greater than 1584, then the Syncfusion DOCX Editor will automatically reset it to 1584.
 
 ## Header distance
 
@@ -54,7 +54,7 @@ documenteditor.selection.sectionFormat.footerDistance = 72;
 
 ## Online demo
 
-Explore how to apply section formatting in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/sectionformat#/tailwind3).
+Explore how to apply section formatting in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/sectionformat#/tailwind3).
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/security-advisories.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/security-advisories.md
@@ -15,11 +15,11 @@ This document provides a description of the security updates available for Syncf
 
 ## Security updates
 
-The following security updates are available for the [ASP.NET Core Document Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) control, listed by release version.
+The following security updates are available for the [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) control, listed by release version.
 
 ### 2024 Volume 2 (v26.2.4) - July 25, 2024
 
-This release resolves critical and moderate security vulnerabilities affecting the ASP.NET Core Document Editor Docker Image.
+This release resolves critical and moderate security vulnerabilities affecting the ASP.NET Core DOCX Editor Docker Image.
 
 **Threat:**
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/shapes.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/shapes.md
@@ -10,13 +10,13 @@ documentation: ug
 
 # Shapes in ASP.NET Core DOCX Editor
 
-Shapes are drawing objects that include a text box, rectangles, lines, curves, circles, etc. It can be preset or custom geometry. At present, the Document Editor does not support inserting shapes. However, if the document contains a shape while importing, it will be preserved properly.
+Shapes are drawing objects that include a text box, rectangles, lines, curves, circles, etc. It can be preset or custom geometry. At present, the DOCX Editor does not support inserting shapes. However, if the document contains a shape while importing, it will be preserved properly.
 
 ## Supported shapes
 
-The [ASP.NET Core Document Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) has preservation support for Lines, Rectangles, Basic Shapes, Block Arrows, Equation Shapes, Flowchart, and Stars and Banners.
+The [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) has preservation support for Lines, Rectangles, Basic Shapes, Block Arrows, Equation Shapes, Flowchart, and Stars and Banners.
 
-![List of supported shapes in Document Editor](images/Shapes_images/supported_shapes.png)
+![List of supported shapes in DOCX Editor](images/Shapes_images/supported_shapes.png)
 
 N> When using ASP.NET MVC service, the unsupported shapes will be converted as image and preserved as image.
 
@@ -28,9 +28,9 @@ A text box is a rectangular area on the document where you can enter text. When 
 
 ## Shape resizer
 
-The Document Editor also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer accepts both touch and mouse interactions.
+The DOCX Editor also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer accepts both touch and mouse interactions.
 
-![Shape resizer view in Document Editor](images/Shapes_images/shape_resizer.png)
+![Shape resizer view in DOCX Editor](images/Shapes_images/shape_resizer.png)
 
 ## Text wrapping style
 
@@ -38,8 +38,8 @@ Text wrapping refers to how shapes fit with surrounding text in a document. [Ref
 
 ## Positioning the shape
 
-The Document Editor preserves the position properties of the shape and displays the shape based on the position properties. It does not support modifying the position properties. However, the shape will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
+The DOCX Editor preserves the position properties of the shape and displays the shape based on the position properties. It does not support modifying the position properties. However, the shape will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
 
 ## Online demo
 
-Explore how to preserve AutoShapes and grouped shapes in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/autoshapes#/tailwind3).
+Explore how to preserve AutoShapes and grouped shapes in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/autoshapes#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/spell-check.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/spell-check.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # Spell Check in ASP.NET Core DOCX Editor
 
-[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) supports performing spell checking for any input text. Spell check is supported on the input text in the Document Editor and provides suggestions for misspelled words through the dialog and the context menu.
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) supports performing spell checking for any input text. Spell check is supported on the input text in the DOCX Editor and provides suggestions for misspelled words through the dialog and the context menu.
 
 
 {% tabs %}
@@ -27,11 +27,11 @@ documentation: ug
 
 ## Enable spellCheck
 
-To enable spell check in the Document Editor, set `enableSpellCheck` to `true` and configure `SpellCheckSettings`.
+To enable spell check in the DOCX Editor, set `enableSpellCheck` to `true` and configure `SpellCheckSettings`.
 
 ## Disable spellCheck
 
-To disable spell check in the Document Editor, set `enableSpellCheck` to `false` or remove the `enableSpellCheck` property initialization code. The default value of this property is false.
+To disable spell check in the DOCX Editor, set `enableSpellCheck` to `false` or remove the `enableSpellCheck` property initialization code. The default value of this property is false.
 
 ## Spell check settings
 
@@ -45,7 +45,7 @@ this.container.documentEditor.spellChecker.removeUnderline = true;
 
 ### AllowSpellCheckAndSuggestion
 
-By default, when you perform a spell check in the Document Editor, both the spelling and suggestions for misspelled words are retrieved, and the words can be corrected through the context menu suggestions. You can modify this behavior using the `allowSpellCheckAndSuggestion` API, which performs only the spell check.
+By default, when you perform a spell check in the DOCX Editor, both the spelling and suggestions for misspelled words are retrieved, and the words can be corrected through the context menu suggestions. You can modify this behavior using the `allowSpellCheckAndSuggestion` API, which performs only the spell check.
 
 ```typescript
 this.container.documentEditor.spellChecker.allowSpellCheckAndSuggestion = false;
@@ -53,7 +53,7 @@ this.container.documentEditor.spellChecker.allowSpellCheckAndSuggestion = false;
 
 ### LanguageID
 
-The Document Editor supports multi-language spell check. You can add as many languages (dictionaries) on the server side; to use a language for spell checking in the Document Editor, it must match the `languageID` you pass to the Document Editor.
+The DOCX Editor supports multi-language spell check. You can add as many languages (dictionaries) on the server side; to use a language for spell checking in the DOCX Editor, it must match the `languageID` you pass to the DOCX Editor.
 
 ```typescript
 this.container.documentEditor.spellChecker.languageID = 1033; //LCID of "en-us";
@@ -61,7 +61,7 @@ this.container.documentEditor.spellChecker.languageID = 1033; //LCID of "en-us";
 
 ### EnableOptimizedSpellCheck
 
-The Document Editor provides an option to spellcheck page by page when loading the documents. The default value of this property is false, so when opening the document spellcheck web API will be called for each word in the document. To optimize the frequency of spellcheck web API calls, you can enable this property.
+The DOCX Editor provides an option to spellcheck page by page when loading the documents. The default value of this property is false, so when opening the document spellcheck web API will be called for each word in the document. To optimize the frequency of spellcheck web API calls, you can enable this property.
 
 ```typescript
 this.container.documentEditor.spellChecker.enableOptimizedSpellCheck = true;

--- a/Document-Processing/Word/Word-Processor/asp-net-core/styles.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/styles.md
@@ -14,7 +14,7 @@ Styles are useful for applying a set of formatting consistently throughout the d
 
 ## Styles definition overview
 
-A style in the Document Editor should have the following properties:
+A style in the DOCX Editor should have the following properties:
 
 * **name**: Name of the style. All styles in a document have a unique name, which is used as an identifier when applying the style.
 * **type**: Specifies the document elements that the style will target. For example, paragraph or character.
@@ -28,7 +28,7 @@ N> The style type should match the inherited style type. For example, it is not 
 
 ## Default style
 
-The default style for span and paragraph properties is `Normal`. It internally inherits the default style of the document loaded or the Document Editor component.
+The default style for span and paragraph properties is `Normal`. It internally inherits the default style of the document loaded or the DOCX Editor component.
 
 ## Style hierarchy
 
@@ -136,4 +136,4 @@ var characterStyles = documentEditor.getStyles('Character');
 
 ## Online Demo
 
-Explore how to apply and modify styles in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/styles#/tailwind3).
+Explore how to apply and modify styles in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/styles#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/supported-fileformats.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/supported-fileformats.md
@@ -14,7 +14,7 @@ domainurl: ##DomainURL##
 
 ## Supported file formats
 
-The following table describes supported formats and their conversion capabilities in the Document Editor.
+The following table describes supported formats and their conversion capabilities in the DOCX Editor.
 
 | File Format | Open | Export |
 |-------------|------|--------|

--- a/Document-Processing/Word/Word-Processor/asp-net-core/table-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/table-format.md
@@ -72,7 +72,7 @@ documenteditor.selection.cellFormat.verticalAlignment= 'Bottom';
 
 ## Table alignment
 
-The tables are aligned in document editor to `Left`, `Right`, or `Center`.
+The tables are aligned in DOCX Editor to `Left`, `Right`, or `Center`.
 
 ```typescript
 documenteditor.selection.tableFormat.tableAlignment='Center';
@@ -109,7 +109,7 @@ You can set the desired width of a table in `Point` or `Percent` type.
 
 ## Apply borders
 
-Document editor exposes APIs to customize the borders for table cells by specifying the settings.
+DOCX Editor exposes APIs to customize the borders for table cells by specifying the settings.
 
 
 {% tabs %}
@@ -123,7 +123,7 @@ Document editor exposes APIs to customize the borders for table cells by specify
 
 ## Working with row formatting
 
-Document editor allows various row formatting such as height and repeat header.
+DOCX Editor allows various row formatting such as height and repeat header.
 
 ### Row height
 
@@ -157,7 +157,7 @@ documenteditor.selection.rowFormat.allowRowBreakAcrossPages=false;
 
 ### Title
 
-Document Editor exposes APIs to get or set the table title of the selected table. Refer to the following sample code to set title.
+DOCX Editor exposes APIs to get or set the table title of the selected table. Refer to the following sample code to set title.
 
 ```typescript
 documenteditor.selection.tableFormat.title = 'Shipping Details';
@@ -165,7 +165,7 @@ documenteditor.selection.tableFormat.title = 'Shipping Details';
 
 ### Description
 
-Document Editor exposes APIs to get or set the table description of the selected table. Refer to the following sample code to set description.
+DOCX Editor exposes APIs to get or set the table description of the selected table. Refer to the following sample code to set description.
 
 ```typescript
 documenteditor.selection.tableFormat.description = 'Freight cost and shipping details';
@@ -173,7 +173,7 @@ documenteditor.selection.tableFormat.description = 'Freight cost and shipping de
 
 ## Online demo
 
-Explore how to format tables in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/tableformat#/tailwind3).
+Explore how to format tables in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/tableformat#/tailwind3).
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/table-of-contents.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/table-of-contents.md
@@ -14,7 +14,7 @@ The table of contents in a document is the same as the list of chapters at the b
 
 ## Inserting table of contents
 
-[ASP.NET Core Document Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) exposes an API to insert a table of contents at the cursor position programmatically. You can specify the settings for the table of contents explicitly. Otherwise, the default settings will be applied.
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) exposes an API to insert a table of contents at the cursor position programmatically. You can specify the settings for the table of contents explicitly. Otherwise, the default settings will be applied.
 
 `TableOfContentsSettings` contain the following properties:
 * **startLevel**: Specifies the start level for constructing table of contents.
@@ -68,7 +68,7 @@ N> The same method is used for inserting, updating, and editing the table of con
 
 ## Online demo
 
-Explore how to insert and update table of contents in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/tableofcontents#/tailwind3).
+Explore how to insert and update table of contents in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/tableofcontents#/tailwind3).
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/table.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/table.md
@@ -10,7 +10,7 @@ documentation: ug
 
 # Tables in ASP.NET Core DOCX Editor
 
-Tables are an efficient way to present information. [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) can display and edit the tables. You can select and edit tables through keyboard, mouse, or touch interactions. Document Editor exposes a rich set of APIs to perform these operations programmatically.
+Tables are an efficient way to present information. [ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) (Document Editor) can display and edit the tables. You can select and edit tables through keyboard, mouse, or touch interactions. DOCX Editor exposes a rich set of APIs to perform these operations programmatically.
 
 ## Create a table
 
@@ -23,7 +23,7 @@ You can create and insert a table at the cursor position by specifying the requi
 ## Set the maximum number of rows when inserting a table
 
 
-You can use the `maximumRows` property to set the maximum number of rows allowed while inserting a table in the Document Editor component.
+You can use the `maximumRows` property to set the maximum number of rows allowed while inserting a table in the DOCX Editor component.
 
 Refer to the following sample code.
 
@@ -51,7 +51,7 @@ N> The maximum value of a row is 32767, as per the Microsoft Word application, a
 ## Set the maximum number of columns when inserting a table
 
 
-You can use the `maximumColumns` property to set the maximum number of columns allowed while inserting a table in the Document Editor component.
+You can use the `maximumColumns` property to set the maximum number of columns allowed while inserting a table in the DOCX Editor component.
 
 Refer to the following sample code.
 
@@ -154,7 +154,7 @@ documenteditor.selection.selectCell();
 
 ## Delete table
 
-Document Editor allows you to delete the entire table. You can use the `deleteTable()` method of the editor instance if the selection is in a table.
+DOCX Editor allows you to delete the entire table. You can use the `deleteTable()` method of the editor instance if the selection is in a table.
 
 ```typescript
 documenteditor.editor.deleteTable();
@@ -162,7 +162,7 @@ documenteditor.editor.deleteTable();
 
 ## Delete row
 
-Document Editor allows you to delete the selected row. You can use the `deleteRow()` method of the editor instance to delete the selected row, if the selection is in a table.
+DOCX Editor allows you to delete the selected row. You can use the `deleteRow()` method of the editor instance to delete the selected row, if the selection is in a table.
 
 ```typescript
 documenteditor.editor.deleteRow();
@@ -170,7 +170,7 @@ documenteditor.editor.deleteRow();
 
 ## Delete column
 
-Document Editor allows you to delete the selected column. You can use the `deleteColumn()` method of the editor instance to delete the selected column, if the selection is in a table.
+DOCX Editor allows you to delete the selected column. You can use the `deleteColumn()` method of the editor instance to delete the selected column, if the selection is in a table.
 
 ```typescript
 documenteditor.editor.deleteColumn();
@@ -186,7 +186,7 @@ documenteditor.editor.mergeCells()
 
 ## Positioning the table
 
-Document Editor preserves the position properties of the table and displays the table based on the position properties. It does not support modifying the position properties. The table will be automatically moved along with the edited text if it is positioned relative to the paragraph.
+DOCX Editor preserves the position properties of the table and displays the table based on the position properties. It does not support modifying the position properties. The table will be automatically moved along with the edited text if it is positioned relative to the paragraph.
 
 ## How to work with tables
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/text-format.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/text-format.md
@@ -125,7 +125,7 @@ documenteditor.selection.characterFormat.fontSize= 32;
 
 ### Change Font Color by UI Option
 
-In the Document Editor, the Text Properties pane features two icons for managing text color within the user interface (UI):
+In the DOCX Editor, the Text Properties pane features two icons for managing text color within the user interface (UI):
 
 * **Colored Box:** This icon visually represents the **current color** applied to the selected text.
 * **Text (A) Icon:** Clicking this icon allows users **to modify the color** of the selected text by choosing a new color from the available options.
@@ -185,7 +185,7 @@ documenteditor.selection.characterFormat.bidi = true;
 
 ## Online demo
 
-Explore how to apply text formatting in Word documents using the ASP.NET Core Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/characterformat#/tailwind3).
+Explore how to apply text formatting in Word documents using the ASP.NET Core DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/characterformat#/tailwind3).
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/asp-net-core/text-wrapping-style.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/text-wrapping-style.md
@@ -16,13 +16,13 @@ Text wrapping refers to how images and shapes are placed within the surrounding 
 
 In this option, the image or shape is placed on the same line and surrounded by text like any other word or letter. This image or shape will be automatically moved along with the text while editing; the other options keep the image or shape in a fixed position while the text shifts and wraps around it.
 
-![View of image with inline wrapping style in the Document Editor.](images/Text-Wrapping-Style_images/inline-textwrapping.PNG)
+![View of image with inline wrapping style in the DOCX Editor.](images/Text-Wrapping-Style_images/inline-textwrapping.PNG)
 
 ## In front of text
 
 In this option, the image or shape is placed in front of the text. This can be used to place an image over some text or to add a shape to highlight part of a paragraph.
 
-![View of image with in front of text wrapping style in the Document Editor.](images/Text-Wrapping-Style_images/infront-textwrapping.PNG)
+![View of image with in front of text wrapping style in the DOCX Editor.](images/Text-Wrapping-Style_images/infront-textwrapping.PNG)
 
 N> Starting from v18.2.0.x, the in front of text wrapping styles are supported.
 
@@ -32,13 +32,13 @@ In this option, text wraps above and below the image or shape. No text is to the
 
 N> Starting from v19.1.0.x, the top and bottom wrapping style is supported.
 
-![View of image with top and bottom wrapping style in the Document Editor.](images/Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
+![View of image with top and bottom wrapping style in the DOCX Editor.](images/Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
 
 ## Behind
 
 In this option, the image or shape is placed behind the text. This can be used when you need to add a watermark or background image to a document.
 
-![View of image with behind wrapping style in the Document Editor.](images/Text-Wrapping-Style_images/behind-textwrapping.PNG)
+![View of image with behind wrapping style in the DOCX Editor.](images/Text-Wrapping-Style_images/behind-textwrapping.PNG)
 
 N> Starting from v19.2.0.x, behind text wrapping styles are supported.
 
@@ -46,6 +46,6 @@ N> Starting from v19.2.0.x, behind text wrapping styles are supported.
 
 In this option, text wraps around the image or text box in a square shape.
 
-N> `Tight` and `Through` styles will be preserved as the `Square` wrapping style in the Document Editor, which is supported from v19.2.0.x.
+N> `Tight` and `Through` styles will be preserved as the `Square` wrapping style in the DOCX Editor, which is supported from v19.2.0.x.
 
-![View of shape with square wrapping style in the Document Editor.](images/Text-Wrapping-Style_images/square-textwrapping.PNG)
+![View of shape with square wrapping style in the DOCX Editor.](images/Text-Wrapping-Style_images/square-textwrapping.PNG)

--- a/Document-Processing/Word/Word-Processor/asp-net-core/track-changes.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/track-changes.md
@@ -9,9 +9,9 @@ documentation: ug
 
 # Track Changes in ASP.NET Core DOCX Editor
 
-Track Changes allows you to keep a record of changes or edits made to a document. You can then choose to accept or reject the modifications. It is a useful tool for managing changes made by several reviewers to the same document. If the track changes option is enabled, all editing operations are preserved as revisions in the Document Editor.
+Track Changes allows you to keep a record of changes or edits made to a document. You can then choose to accept or reject the modifications. It is a useful tool for managing changes made by several reviewers to the same document. If the track changes option is enabled, all editing operations are preserved as revisions in the DOCX Editor.
 
-## Enable track changes in Document Editor
+## Enable track changes in DOCX Editor
 
 The following example demonstrates how to enable track changes.
 
@@ -90,7 +90,7 @@ revisions.rejectAll();
 
 ## Accept or reject a specific revision
 
-The following example demonstrates how to accept or reject a specific revision in the Document Editor.
+The following example demonstrates how to accept or reject a specific revision in the DOCX Editor.
 
 ```typescript
 /**
@@ -131,7 +131,7 @@ In DocumentEditor, we have built-in review panel in which we have provided suppo
 
 ## Custom metadata along with author
 
-The Document Editor provides options to customize revisions using `revisionSettings`. The `customData` property allows you to attach additional metadata to tracked revisions in the Word Processor. This metadata can represent roles, tags, or any custom identifier for the revision. To display this metadata along with the author name in the Track Changes pane, you must enable the `showCustomDataWithAuthor` property.
+The DOCX Editor provides options to customize revisions using `revisionSettings`. The `customData` property allows you to attach additional metadata to tracked revisions in the Word Processor. This metadata can represent roles, tags, or any custom identifier for the revision. To display this metadata along with the author name in the Track Changes pane, you must enable the `showCustomDataWithAuthor` property.
 
 The following example code illustrates how to enable and update custom metadata for track changes revisions.
 
@@ -148,13 +148,13 @@ The Track Changes pane will display the author name along with the custom metada
 
 ![Custom metadata along with author](images/track-changes-customData.png)
 
-N> When you export the document as SFDT, the `customData` value is stored in the revision collection. When you reopen the SFDT, the custom data is automatically restored and displayed in the Track Changes pane. For other formats such as DOCX, the `customData` is not preserved, as it is specific to the Document Editor component.
+N> When you export the document as SFDT, the `customData` value is stored in the revision collection. When you reopen the SFDT, the custom data is automatically restored and displayed in the Track Changes pane. For other formats such as DOCX, the `customData` is not preserved, as it is specific to the DOCX Editor component.
 
 ## Protect the document in track changes only mode
 
-Document Editor provides support for protecting the document with `RevisionsOnly` protection. In this protection, all the users are allowed to view the document and do their corrections, but they cannot accept or reject any tracked changes in the document. Later, the author can view their corrections and accept or reject the changes.
+DOCX Editor provides support for protecting the document with `RevisionsOnly` protection. In this protection, all the users are allowed to view the document and do their corrections, but they cannot accept or reject any tracked changes in the document. Later, the author can view their corrections and accept or reject the changes.
 
-The Document Editor provides an option to protect and unprotect the document using the `enforceProtection` and `stopProtection` APIs.
+The DOCX Editor provides an option to protect and unprotect the document using the `enforceProtection` and `stopProtection` APIs.
 
 The following example code illustrates how to enforce and stop protection in the Document Editor container.
 
@@ -177,4 +177,4 @@ N> In the `EnforceProtection` method, the first parameter is the password and th
 
 ## Online demo
 
-Explore how to track and review changes in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/trackchanges#/tailwind3).
+Explore how to track and review changes in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/trackchanges#/tailwind3).

--- a/Document-Processing/Word/Word-Processor/asp-net-core/view.md
+++ b/Document-Processing/Word/Word-Processor/asp-net-core/view.md
@@ -11,7 +11,7 @@ documentation: ug
 
 ## Web layout
 
-[ASP.NET Core Document Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) allows you to change the view to either web layout or print using the [`LayoutType`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_LayoutType) property with the supported [`LayoutType`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.LayoutType.html) enum.
+[ASP.NET Core DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/asp-net-core-docx-editor) allows you to change the view to either web layout or print using the [`LayoutType`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.DocumentEditor.html#Syncfusion_EJ2_DocumentEditor_DocumentEditor_LayoutType) property with the supported [`LayoutType`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.DocumentEditor.LayoutType.html) enum.
 
 
 {% tabs %}
@@ -24,13 +24,13 @@ documentation: ug
 
 ### Online demo
 
-Explore how to view Word documents in web layout using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/weblayout#/tailwind3).
+Explore how to view Word documents in web layout using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/weblayout#/tailwind3).
 
 ## Ruler
 
-The ruler helps you set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the Document Editor.
+The ruler helps you set specific margins, tab stops, or indentations within a document to ensure consistent formatting in the DOCX Editor.
 
-The following example illustrates how to enable the ruler in the Document Editor.
+The following example illustrates how to enable the ruler in the DOCX Editor.
 
 
 {% tabs %}
@@ -44,13 +44,13 @@ The following example illustrates how to enable the ruler in the Document Editor
 
 ### Online demo
 
-Explore how to use the ruler in the ASP.NET Core Document Editor for working with Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/ruler#/tailwind3).
+Explore how to use the ruler in the ASP.NET Core DOCX Editor for working with Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/ruler#/tailwind3).
 
 ## Navigation pane
 
 The heading navigation pane allows users to swiftly navigate documents by heading, enhancing their ability to move through the document efficiently.
 
-The following example illustrates how to enable the heading navigation pane in the Document Editor.
+The following example illustrates how to enable the heading navigation pane in the DOCX Editor.
 
 
 {% tabs %}
@@ -64,4 +64,4 @@ The following example illustrates how to enable the heading navigation pane in t
 
 ### Online demo
 
-Explore how to navigate through headings in Word documents using the ASP.NET Core Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/headingnavigation#/tailwind3).
+Explore how to navigate through headings in Word documents using the ASP.NET Core DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/asp-net-core/documenteditor/headingnavigation#/tailwind3).


### PR DESCRIPTION
## Description 

Resolved redundant keyword usage in ASP .NET Core DOCX Editor.

Reduced the occurrences of "**_Document Editor_**" wherever possible, replacing it with "**_DOCX Editor_**" 

## Before
<img width="1187" height="856" alt="image" src="https://github.com/user-attachments/assets/225c48ca-d670-43df-9a47-383f53ea444c" />

## After
<img width="1182" height="859" alt="image" src="https://github.com/user-attachments/assets/4ddc1f5b-6cb4-4e78-aba2-86bbd9f429d8" />

## Final Data

The occurrence count of **99** is present in the following areas, which have been intentionally ignored:

1. "Document Editor" maintained within the brackets in the first paragraph of every UG page.
2. Document Editor Settings.
3. Document Editor Container.
4. Code blocks and code comments.

These occurrences were not modified because they are part of standard checklist content, feature names, container names, or code-related content.
