### PR TITLE
Task(1050024) - Resolved redundant keyword usage in Blazor DOCX Editor

### DIFF
--- a/Document-Processing/Word/Word-Processor/blazor/accessibility.md
+++ b/Document-Processing/Word/Word-Processor/blazor/accessibility.md
@@ -3,7 +3,7 @@ layout: post
 title: Accessibility in Blazor DOCX Editor | Syncfusion
 description: The accessibility support in Blazor DOCX Editor ensures keyboard navigation, screen reader compatibility, and an inclusive document editing experience.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,7 +11,7 @@ documentation: ug
 
 The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) component follows the accessibility guidelines and standards, including [ADA](https://www.ada.gov/), [Section 508](https://www.section508.gov/), [WCAG 2.2](https://www.w3.org/TR/WCAG22/), and [WCAG roles](https://www.w3.org/TR/wai-aria#roles) used to evaluate accessibility compliance.
 
-The accessibility compliance for the Blazor Document Editor component is outlined below.
+The accessibility compliance for the Blazor DOCX Editor component is outlined below.
 
 | Accessibility Criteria | Compatibility |
 | -- | -- |
@@ -38,11 +38,11 @@ The accessibility compliance for the Blazor Document Editor component is outline
 
 ## Keyboard interaction
 
-The Document Editor supports a wide range of keyboard shortcuts to facilitate common actions, including text formatting, paragraph formatting, navigation, and editing.
+The DOCX Editor supports a wide range of keyboard shortcuts to facilitate common actions, including text formatting, paragraph formatting, navigation, and editing.
 
 ### Text formatting
 
-The following table lists the default keyboard shortcuts in the Document Editor for formatting text:
+The following table lists the default keyboard shortcuts in the DOCX Editor for formatting text:
 
 | Windows | Mac | Description |
 |-----------------|------|-------|
@@ -156,13 +156,13 @@ The following table lists the default keyboard shortcuts for formatting the para
 |<kbd>Ctrl</kbd> + <kbd>D</kbd> | <kbd>⌘</kbd> + <kbd>D</kbd> | Opens the font dialog.|
 |<kbd>Ctrl</kbd> + <kbd>K</kbd> | <kbd>⌘</kbd> + <kbd>K</kbd> | Opens the hyperlink dialog.|
 
-Refer to the Blazor Document Editor feature tour page for its groundbreaking feature representations. You can also explore our [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to learn how to render and configure the Document Editor.
+Refer to the Blazor DOCX Editor feature tour page for its groundbreaking feature representations. You can also explore our [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to learn how to render and configure the DOCX Editor.
 
 ## Ensuring accessibility
 
-The Blazor Document Editor component accessibility levels are ensured through an [axe-core](https://www.nuget.org/packages/Deque.AxeCore.Playwright) software tool during automated testing.
+The Blazor DOCX Editor component accessibility levels are ensured through an [axe-core](https://www.nuget.org/packages/Deque.AxeCore.Playwright) software tool during automated testing.
 
-The accessibility compliance of the Blazor Document Editor component is shown in the following sample. Open the [sample](https://blazor.syncfusion.com/accessibility/document-editor) in a new window to evaluate the accessibility of the Document Editor component with accessibility tools.
+The accessibility compliance of the Blazor DOCX Editor component is shown in the following sample. Open the [sample](https://blazor.syncfusion.com/accessibility/document-editor) in a new window to evaluate the accessibility of the DOCX Editor component with accessibility tools.
 
 ## See also
 

--- a/Document-Processing/Word/Word-Processor/blazor/bookmark.md
+++ b/Document-Processing/Word/Word-Processor/blazor/bookmark.md
@@ -3,7 +3,7 @@ layout: post
 title: Bookmarks in Blazor DOCX Editor | Syncfusion
 description: The bookmark feature in Blazor DOCX Editor lets users add, manage, and navigate bookmarks for quick access to specific document sections.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -54,4 +54,4 @@ N> The boolean parameter of `GetBookmarksAsync` specifies whether to include hid
 
 ## Online demo
 
-Explore how to insert and manage bookmarks in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/hyperlinks-and-bookmarks?theme=fluent2).
+Explore how to insert and manage bookmarks in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/hyperlinks-and-bookmarks?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/clipboard.md
+++ b/Document-Processing/Word/Word-Processor/blazor/clipboard.md
@@ -3,7 +3,7 @@ layout: post
 title: Clipboard in Blazor DOCX Editor | Syncfusion
 description: The clipboard support in Blazor DOCX Editor provides copy, cut, paste, and local paste operations for efficient content management.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,14 +13,14 @@ The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-
 
 ## Local vs. System Clipboard
 
-The Document Editor supports two clipboard modes to handle content transfer:
+The DOCX Editor supports two clipboard modes to handle content transfer:
 
-To copy or paste content from other applications, use the system clipboard. To copy or paste content within the Document Editor component, use the local clipboard.
+To copy or paste content from other applications, use the system clipboard. To copy or paste content within the DOCX Editor component, use the local clipboard.
 
 Let’s see how to invoke each clipboard operation using code.
 
 *   **Local Clipboard (Default)**: This is a built-in clipboard that is optimized for performance when cutting, copying, and pasting content **within** the editor itself. It is enabled by default.
-*   **System Clipboard**: This is the operating system's standard clipboard, which allows for transferring content between the Document Editor and other applications.
+*   **System Clipboard**: This is the operating system's standard clipboard, which allows for transferring content between the DOCX Editor and other applications.
 
 To use the system clipboard, set the [`EnableLocalPaste`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_EnableLocalPaste) property to `false`. When this property is `false`, all clipboard operations will use the system clipboard.
 
@@ -71,6 +71,6 @@ The [`PasteAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Docum
 *   If `true` (default), it pastes from the editor's local clipboard.
 *   If `false`, it pastes from the system clipboard.
 
-N> When you paste content from an external source into the Document Editor, some formatting or elements may not appear as expected because certain elements are not supported. Refer to the [unsupported features](./unsupported-features) documentation to learn more about unsupported elements.
+N> When you paste content from an external source into the DOCX Editor, some formatting or elements may not appear as expected because certain elements are not supported. Refer to the [unsupported features](./unsupported-features) documentation to learn more about unsupported elements.
 
-Explore the [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to see how to render and configure the Document Editor.
+Explore the [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to see how to render and configure the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/comments.md
+++ b/Document-Processing/Word/Word-Processor/blazor/comments.md
@@ -3,7 +3,7 @@ layout: post
 title: Comments in Blazor DOCX Editor | Syncfusion
 description: The comments feature in Blazor DOCX Editor enables users to add, review, navigate, reply to, and manage comments within documents.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -49,9 +49,9 @@ await container.DocumentEditor.Editor.DeleteAllCommentsAsync();
 
 ## Protect the document in comments-only mode
 
-The Document Editor supports a special protection mode that restricts user actions to adding or editing comments only. When `CommentsOnly` protection is active, users cannot change the document content.
+The DOCX Editor supports a special protection mode that restricts user actions to adding or editing comments only. When `CommentsOnly` protection is active, users cannot change the document content.
 
-The Document Editor provides APIs to protect and unprotect the document using [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_).
+The DOCX Editor provides APIs to protect and unprotect the document using [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_).
 
 The following example code illustrates how to enforce and stop protection in the Document Editor container.
 
@@ -81,4 +81,4 @@ N> In the `EnforceProtection` method, the first parameter is the password and th
 
 ## Online demo
 
-Explore how to add, view, and manage comments in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/comments?theme=fluent2).
+Explore how to add, view, and manage comments in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/comments?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/faq/sfdt-faqs.md
+++ b/Document-Processing/Word/Word-Processor/blazor/faq/sfdt-faqs.md
@@ -14,11 +14,11 @@ The frequently asked questions about SFDT in [Blazor DOCX Editor](https://www.sy
 
 ## What is SFDT format?
 
-SFDT (Syncfusion Document Text) is a JSON-based representation of a DOCX document used internally by the Document Editor. It is not a new file format; instead, it is a structured JSON equivalent of a DOCX file, designed to represent the same content as the original document. SFDT uses a hierarchical key-value structure to describe document elements such as sections, paragraphs, text, styles, tables, and images, closely matching the structure of a Word document.
+SFDT (Syncfusion Document Text) is a JSON-based representation of a DOCX document used internally by the DOCX Editor. It is not a new file format; instead, it is a structured JSON equivalent of a DOCX file, designed to represent the same content as the original document. SFDT uses a hierarchical key-value structure to describe document elements such as sections, paragraphs, text, styles, tables, and images, closely matching the structure of a Word document.
 
 ## Is it possible to modify SFDT?
 
-It is not recommended to modify SFDT directly (either manually or programmatically). The format is designed for internal use by the Document Editor, and even small changes can break the document structure or cause unexpected behavior.
+It is not recommended to modify SFDT directly (either manually or programmatically). The format is designed for internal use by the DOCX Editor, and even small changes can break the document structure or cause unexpected behavior.
 
 ## What are the advantages of SFDT over DOCX?
 
@@ -34,14 +34,14 @@ SFDT is optimized for web-based document editing scenarios.
 
 SFDT is suitable in the following scenarios:
 
-- Applications where documents are edited within the browser using the Document Editor, and the document state needs to be saved and reopened later in the same editor.
+- Applications where documents are edited within the browser using the DOCX Editor, and the document state needs to be saved and reopened later in the same editor.
 
 - Use cases that require efficient storage in a database and quick reloading for further editing.
 
 ## Can SFDT be converted back to DOCX?
 
-Yes. You can convert SFDT back to DOCX or other [supported formats](../supported-fileformats) in the Document Editor.
+Yes. You can convert SFDT back to DOCX or other [supported formats](../supported-fileformats) in the DOCX Editor.
 
 ## Are any features unavailable when using SFDT?
 
-No. SFDT fully represents the document structure in a manner similar to DOCX, so all Document Editor features are supported when working with SFDT.
+No. SFDT fully represents the document structure in a manner similar to DOCX, so all DOCX Editor features are supported when working with SFDT.

--- a/Document-Processing/Word/Word-Processor/blazor/faq/unsupported-file-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/faq/unsupported-file-format.md
@@ -3,7 +3,7 @@ layout: post
 title: Supported File Formats in Blazor DOCX Editor | Syncfusion
 description: Learn about the supported file formats in Blazor DOCX Editor for importing, and exporting documents.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,12 +11,12 @@ documentation: ug
 
 If the message “The file format you have selected isn’t supported. Please choose a valid format.” appears when opening a document in the [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor), it generally indicates that the file is not provided in a supported format for the current workflow. Here are some common reasons:
 
-1. **Unsupported File Format**: The document you are trying to open might be in a format that the Document Editor does not support. Ensure you are using a supported format, such as SFDT.
+1. **Unsupported File Format**: The document you are trying to open might be in a format that the DOCX Editor does not support. Ensure you are using a supported format, such as SFDT.
 2. **Corrupted Document**: The document file might be corrupted or improperly formatted. Try opening a different document to see if the issue persists.
 
-To avoid this warning, always use the recommended document formats and features supported by the Document Editor.
+To avoid this warning, always use the recommended document formats and features supported by the DOCX Editor.
 
-The Document Editor supports the following file formats:
+The DOCX Editor supports the following file formats:
 
 * Word Document (*.docx)
 * Syncfusion Document Text (*.sfdt)
@@ -28,4 +28,4 @@ The Document Editor supports the following file formats:
 * Word 97-2003 Template (*.dot)
 * Word 97-2003 Document (*.doc)
 
-By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the Document Editor.
+By using these supported formats, you can ensure compatibility and avoid unsupported warning messages when opening documents in the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/fields.md
+++ b/Document-Processing/Word/Word-Processor/blazor/fields.md
@@ -3,7 +3,7 @@ layout: post
 title: Fields in Blazor DOCX Editor | Syncfusion
 description: Fields in Blazor DOCX Editor enable inserting and updating document fields to manage dynamic content efficiently.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,11 +11,11 @@ documentation: ug
 
 Fields are placeholders in a document that display data that can change, such as the current date, the total number of pages, or information from a data source (like in a mail merge). The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) is designed to preserve all field types when loading an existing document, ensuring that no data or functionality is lost.
 
-This document explains how to update fields and interact with them programmatically using the Document Editor's APIs.
+This document explains how to update fields and interact with them programmatically using the DOCX Editor's APIs.
 
 ## Automatic and manual field updates
 
-Certain fields are automatically updated by the Document Editor as the document's content changes.
+Certain fields are automatically updated by the DOCX Editor as the document's content changes.
 
 ### Automatically updated fields
 
@@ -32,7 +32,7 @@ Other fields, such as bookmark cross-references, must be updated manually. This 
 
 To update all fields in the document, click the **Update Fields** button in the **Review** tab of the toolbar.
 
-![The Update Fields button in the Blazor Document Editor toolbar.](images/updatefields.png)
+![The Update Fields button in the Blazor DOCX Editor toolbar.](images/updatefields.png)
 
 #### Update programmatically
 
@@ -45,11 +45,11 @@ await container.DocumentEditor.UpdateFieldsAsync();
 
 ## Programmatically interacting with fields
 
-The Document Editor provides APIs to insert fields and to get or set the information of an existing field.
+The DOCX Editor provides APIs to insert fields and to get or set the information of an existing field.
 
 ### Inserting a field
 
-The following type of fields are automatically updated in Document Editor.
+The following type of fields are automatically updated in DOCX Editor.
 
 A new field can be inserted at the current selection using the [`InsertFieldAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_InsertFieldAsync_System_String_System_String_) method. This requires specifying both the `fieldCode` and the `fieldResult`.
 
@@ -67,7 +67,7 @@ string fieldResult = "«First Name»";
 await container.DocumentEditor.Editor.InsertFieldAsync(fieldCode, fieldResult);
 ```
 
-N> The Document Editor does not validate the field code or result; it simply inserts a field with the provided information.
+N> The DOCX Editor does not validate the field code or result; it simply inserts a field with the provided information.
 
 ### Getting and modifying field information
 

--- a/Document-Processing/Word/Word-Processor/blazor/find-and-replace.md
+++ b/Document-Processing/Word/Word-Processor/blazor/find-and-replace.md
@@ -3,7 +3,7 @@ layout: post
 title: Find and Replace in Blazor DOCX Editor | Syncfusion
 description: The find and replace feature in Blazor DOCX Editor helps users quickly locate specific content and replace it throughout a document.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -53,4 +53,4 @@ You can invoke the search or find text functionality programmatically using the 
 }
 ```
 
-You can refer to our [Blazor Document Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) feature tour page for a complete feature overview. You can also explore our [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to see how to render and configure the document editor.
+You can refer to our [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) feature tour page for a complete feature overview. You can also explore our [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to see how to render and configure the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/form-fields.md
+++ b/Document-Processing/Word/Word-Processor/blazor/form-fields.md
@@ -3,7 +3,7 @@ layout: post
 title: Form Fields in Blazor DOCX Editor | Syncfusion
 description: Form fields in Blazor DOCX Editor allow users to create, update, and protect fillable fields for structured data entry.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -75,9 +75,9 @@ await container.DocumentEditor.ResetFormFieldsAsync();
 
 ## Protect the document in form filling mode
 
-Document Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
+DOCX Editor provides support for protecting the document with `FormFieldsOnly` protection. In this protection, the user can only fill form fields in the document.
 
-The Document Editor provides an option to protect and unprotect a document using the [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_) APIs.
+The DOCX Editor provides an option to protect and unprotect a document using the [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_) APIs.
 
 The following example code illustrates how to enforce and stop protection in the Document Editor container.
 
@@ -103,4 +103,4 @@ N> In the `EnforceProtection` method, the first parameter denotes the password a
 
 ## Online Demo
 
-Explore how to insert and manage form fields in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/form-fields?theme=fluent2).
+Explore how to insert and manage form fields in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/form-fields?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/header-footer.md
+++ b/Document-Processing/Word/Word-Processor/blazor/header-footer.md
@@ -3,7 +3,7 @@ layout: post
 title: Headers and Footers in Blazor DOCX Editor | Syncfusion
 description: Headers and footers in Blazor DOCX Editor enable adding and customizing content at the top and bottom of document pages.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -60,4 +60,4 @@ await container.DocumentEditor.Selection.CloseHeaderFooterAsync();
 
 ## Online demo
 
-Explore how to add and customize headers and footers in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/headers-and-footers?theme=fluent2).
+Explore how to add and customize headers and footers in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/headers-and-footers?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/history.md
+++ b/Document-Processing/Word/Word-Processor/blazor/history.md
@@ -3,7 +3,7 @@ layout: post
 title: History in Blazor DOCX Editor | Syncfusion
 description: History in Blazor DOCX Editor tracks editing actions to enable undo and redo operations for efficient document editing.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -15,7 +15,7 @@ This functionality is enabled by default through the integrated `EditorHistoryMo
 
 ## Enable or disable history
 
-Inject the [`EditorHistory`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorHistoryModule.html) module to enable history tracking for the [`Document Editor`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html). Refer to the following code example.
+Inject the [`EditorHistory`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorHistoryModule.html) module to enable history tracking for the [`DOCX Editor`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html). Refer to the following code example.
 
 ```cshtml
 @using Syncfusion.Blazor.DocumentEditor
@@ -33,7 +33,7 @@ Inject the [`EditorHistory`](https://help.syncfusion.com/cr/blazor/Syncfusion.Bl
 }
 ```
 
-Enable or disable history preservation for a Document Editor instance at any time using the `EnableEditorHistory` property. Refer to the following sample code.
+Enable or disable history preservation for a DOCX Editor instance at any time using the `EnableEditorHistory` property. Refer to the following sample code.
 
 ```csharp
 documentEditor.EnableEditorHistory = true;
@@ -41,8 +41,8 @@ documentEditor.EnableEditorHistory = true;
 
 ## Undo and redo
 
-You can perform undo and redo by using `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts. The Document Editor exposes APIs to do this programmatically.
-To undo the last editing operation in the Document Editor, refer to the following sample code.
+You can perform undo and redo by using `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts. The DOCX Editor exposes APIs to do this programmatically.
+To undo the last editing operation in the DOCX Editor, refer to the following sample code.
 
 ```csharp
 await container.DocumentEditor.EditorHistory.UndoAsync();
@@ -56,10 +56,10 @@ await container.DocumentEditor.EditorHistory.RedoAsync();
 
 ## Stack size
 
-History of editing actions is maintained in a stack, so that the last item is reverted first. By default, the Document Editor limits the size of the undo and redo stacks to 500 each. However, you can customize this limit. Refer to the following sample code.
+History of editing actions is maintained in a stack, so that the last item is reverted first. By default, the DOCX Editor limits the size of the undo and redo stacks to 500 each. However, you can customize this limit. Refer to the following sample code.
 
 ```csharp
 await container.DocumentEditor.EditorHistory.SetRedoLimitAsync(400);
 ```
 
-Explore the [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to understand how to render and configure the Document Editor.
+Explore the [Blazor Word Processor example](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) to understand how to render and configure the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/add-save-button-in-toolbar.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/add-save-button-in-toolbar.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Add Save Button in Toolbar in Blazor DOCX Editor | Syncfusion
 description: Add a custom save button to the toolbar in Syncfusion® Blazor DOCX Editor, customize toolbar items, and perform document save operations.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 # How to Add Save Button in Toolbar in Blazor DOCX Editor

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/auto-save-document.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/auto-save-document.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Auto Save Document in Blazor DOCX Editor | Syncfusion
 description: Automatically save edited documents to the server at regular intervals in Syncfusion® Blazor DOCX Editor to prevent data loss.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 # How to Auto Save Document in Blazor DOCX Editor
@@ -78,4 +78,4 @@ The following example illustrates how to auto-save the document to the server.
 
 ## Online demo
 
-Explore how to automatically save Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities).
+Explore how to automatically save Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities).

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/change-document-view.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/change-document-view.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Change Document View in Blazor DOCX Editor | Syncfusion
 description: Change the document view to web layout or print layout in Syncfusion® Blazor DOCX Editor using layout type settings.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -18,7 +18,7 @@ The two available layout types are:
 
 ## Setting the layout type
 
-The layout type can be set during component initialization. The following example demonstrates how to configure the Document Editor to use the `Continuous` (Web Layout) view.
+The layout type can be set during component initialization. The following example demonstrates how to configure the DOCX Editor to use the `Continuous` (Web Layout) view.
 
 ```
 @using Syncfusion.Blazor.DocumentEditor

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/change-the-cursor-color-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/change-the-cursor-color-in-document-editor.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Change Cursor Color in Blazor DOCX Editor | Syncfusion
 description: Change the default cursor color in Syncfusion® Blazor DOCX Editor by overriding CSS properties and customizing the editor appearance.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -23,6 +23,6 @@ The editor's blinking cursor is styled using the `.e-de-blink-cursor` CSS class.
 
 N> The `!important` declaration is used here to ensure this custom style takes precedence over the component's default styles.
 
-After applying this CSS, the cursor in the Document Editor will appear in the new color.
+After applying this CSS, the cursor in the DOCX Editor will appear in the new color.
 
-![Cursor shown in red in the Blazor Document Editor.](../images/cursor-css.png)
+![Cursor shown in red in the Blazor DOCX Editor.](../images/cursor-css.png)

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/customize-color-picker.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/customize-color-picker.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Customize Color Picker in Blazor DOCX Editor | Syncfusion
 description: Customize the color picker appearance in Syncfusion® Blazor DOCX Editor using color picker settings to match your application's design.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -41,4 +41,4 @@ The following table illustrates all the possible properties for the color picker
 
 ## Online demo
 
-Explore how to customize the color picker in the Blazor Document Editor for Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/color-picker-customization?theme=fluent2).
+Explore how to customize the color picker in the Blazor DOCX Editor for Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/color-picker-customization?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/customize-context-menu.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/customize-context-menu.md
@@ -53,7 +53,7 @@ The following code shows how to add a custom option in the context menu.
 
 ### Customize a custom option in the context menu
 
-The Blazor Document Editor component allows you to customize added custom options and show or hide the default context menu.
+The Blazor DOCX Editor component allows you to customize added custom options and show or hide the default context menu.
 
 #### Hide default context menu items
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/customize-context-menu.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/customize-context-menu.md
@@ -3,13 +3,13 @@ layout: post
 title: How to Customize Context Menu in Blazor DOCX Editor | Syncfusion
 description: Customize the context menu in Syncfusion® Blazor DOCX Editor by adding custom menu items, modifying existing options, and handling menu actions.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # How to Customize Context Menu in Blazor DOCX Editor
 
-## How to customize the context menu in the Document Editor
+## How to customize the context menu in the DOCX Editor
 
 The [`Blazor DOCX Editor`](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) component allows you to customize added custom options and show or hide the default context menu. Use the [`AddCustomMenu()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.ContextMenuModule.html#Syncfusion_Blazor_DocumentEditor_ContextMenuModule_AddCustomMenu_System_Collections_Generic_List_Syncfusion_Blazor_DocumentEditor_MenuItemModel__System_Boolean_System_Boolean_) method to add custom options, and define custom actions using the [`ContextMenuItemSelected`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorEvents.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorEvents_ContextMenuItemSelected) event.
 
@@ -81,4 +81,4 @@ The following code shows how to hide the default context menu and add a custom o
 
 ## Online demo
 
-Explore how to customize the context menu in the Blazor Document Editor for working with Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/custom-context-menu?theme=fluent2).
+Explore how to customize the context menu in the Blazor DOCX Editor for working with Word documents in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/custom-context-menu?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/customize-tool-bar.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/customize-tool-bar.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Customize Toolbar in Blazor DOCX Editor | Syncfusion
 description: Customize the toolbar in Syncfusion® Blazor DOCX Editor by adding, removing, showing, hiding, enabling, and disabling toolbar items.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -45,4 +45,4 @@ N> The default value of `ToolbarItems` is `['New', 'Open', 'Separator', 'Undo', 
 
 ## Online Demo
 
-Explore how to customize the toolbar in the Blazor Document Editor for working with Word documents in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/toolbar-customization?theme=fluent2).
+Explore how to customize the toolbar in the Blazor DOCX Editor for working with Word documents in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/toolbar-customization?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/disable-optimized-text-measuring.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/disable-optimized-text-measuring.md
@@ -3,7 +3,7 @@ layout: post
 title: Disable Optimized Text Measuring in Blazor DOCX Editor | Syncfusion
 description: Disable optimized text measuring in Syncfusion® Blazor DOCX Editor to retain document pagination behavior and maintain layout consistency.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,7 +11,7 @@ documentation: ug
 
 Starting from v19.3.0.x, the accuracy of text size measurements in [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) is improved to match Microsoft Word pagination for most Word documents. This improvement is included as default behavior along with an optional API [`EnableOptimizedTextMeasuring`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_EnableOptimizedTextMeasuring) in Document Editor settings.  
 
-Blazor Document Editor component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions, you can disable the optimized text measuring feature by setting `false` to the [`EnableOptimizedTextMeasuring`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_EnableOptimizedTextMeasuring) property of the Blazor Document Editor component.
+Blazor DOCX Editor component to retain the document pagination (display page-by-page) behavior like v19.2.0.x and older versions, you can disable the optimized text measuring feature by setting `false` to the [`EnableOptimizedTextMeasuring`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_EnableOptimizedTextMeasuring) property of the Blazor DOCX Editor component.
 
 ## Disable optimized text measuring in Document Editor Container instance
 
@@ -31,9 +31,9 @@ The following example code illustrates how to disable the optimized text measuri
 }
 ```
 
-## Disable optimized text measuring in Document Editor instance
+## Disable optimized text measuring in DOCX Editor instance
 
-The following example code illustrates how to disable the optimized text measuring feature in the [`Document Editor`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html) instance.
+The following example code illustrates how to disable the optimized text measuring feature in the [`DOCX Editor`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html) instance.
 
 ```csharp
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/enable-ruler-in-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/enable-ruler-in-document-editor.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Enable Ruler in Blazor DOCX Editor | Syncfusion
 description: Enable the ruler in Syncfusion® Blazor DOCX Editor to set margins, tab stops, and paragraph indentations for precise document formatting.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/export-document-as-pdf.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/export-document-as-pdf.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Export Document as PDF in Blazor DOCX Editor | Syncfusion
 description: Export documents as PDF in Syncfusion® Blazor DOCX Editor using client-side and server-side export options for flexible document sharing.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/get-current-word.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/get-current-word.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Get Current Word in Blazor DOCX Editor | Syncfusion
 description: Get the current word or paragraph content as plain text and SFDT format in Syncfusion® Blazor DOCX Editor for content processing and analysis.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-
 
 ## Select and get the word at the current cursor position
 
-Use the [`SelectCurrentWordAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectCurrentWordAsync_System_Boolean_) API in the selection module to select the current word at the cursor position. Then, use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the selected content as plain text from the Blazor Document Editor component.
+Use the [`SelectCurrentWordAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectCurrentWordAsync_System_Boolean_) API in the selection module to select the current word at the cursor position. Then, use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the selected content as plain text from the Blazor DOCX Editor component.
 
 The following example code illustrates how to select and get the current word as plain text.
 
@@ -43,7 +43,7 @@ To get the bookmark content as SFDT (rich text), check this [`link`](./get-the-s
 
 ## Select and get the paragraph at the current cursor position
 
-You can use the [`SelectParagraphAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectParagraphAsync) API in the selection module to select the current paragraph at the cursor position, and use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API or the [`GetSfdtAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetSfdtAsync) API to get the selected content as plain text or SFDT from the Blazor Document Editor component.
+You can use the [`SelectParagraphAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectParagraphAsync) API in the selection module to select the current paragraph at the cursor position, and use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API or the [`GetSfdtAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetSfdtAsync) API to get the selected content as plain text or SFDT from the Blazor DOCX Editor component.
 
 The following example code illustrates how to select and get the current paragraph as SFDT.
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/get-the-selected-content.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/get-the-selected-content.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Get Selected Content in Blazor DOCX Editor | Syncfusion
 description: Get selected content as plain text and SFDT rich text in Syncfusion® Blazor DOCX Editor for content extraction, processing, and customization.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ You can get the selected content from the [Blazor DOCX Editor](https://www.syncf
 
 ## Get the selected content as plain text
 
-You can use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the selected content as plain text from the Blazor Document Editor component.
+You can use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the selected content as plain text from the Blazor DOCX Editor component.
 
 The following example code illustrates how to add a "Search in Google" option to the context menu for the selected text.
 
@@ -60,7 +60,7 @@ The following custom options can be added using this API:
 
 ## Get the selected content as SFDT (rich text)
 
-You can use the [`GetSfdtAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetSfdtAsync) API to get the selected content as SFDT (rich text) from the Blazor Document Editor component.
+You can use the [`GetSfdtAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetSfdtAsync) API to get the selected content as SFDT (rich text) from the Blazor DOCX Editor component.
 
 The following example code illustrates how to get the content of a bookmark and export it as SFDT.
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/hide-tool-bar-and-properties-pane.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/hide-tool-bar-and-properties-pane.md
@@ -3,7 +3,7 @@ layout: post
 title: Hide Toolbar and Properties Pane in Blazor DOCX Editor | Syncfusion
 description: Hide the toolbar and properties pane in Syncfusion® Blazor DOCX Editor to create a custom user interface and streamline the document editing experience.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,7 +11,7 @@ documentation: ug
 
 **[Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) container** provides the main document view area along with the built-in toolbar and properties pane.
 
-**Document Editor** provides just the main document view area. Here, the user can compose, view, and edit the Word documents. Use this component when you want to design your own UI options for your application.
+**DOCX Editor** provides just the main document view area. Here, the user can compose, view, and edit the Word documents. Use this component when you want to design your own UI options for your application.
 
 ## Hide the properties pane
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/insert-page-number-and-navigate-to-page.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/insert-page-number-and-navigate-to-page.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Insert Page Numbers in Blazor DOCX Editor | Syncfusion
 description: Insert page numbers and navigate to specific pages in Syncfusion® Blazor DOCX Editor using built-in APIs for efficient document navigation and formatting.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -15,7 +15,7 @@ You can insert a page number and navigate to a specific page in the [Blazor DOCX
 
 The [`InsertFieldAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_InsertFieldAsync_System_String_System_String_) API in the Editor module is used to insert the page number at the current position. By default, the page number will be inserted in Arabic number style.
 
-N> Currently, the Document Editor has an option to insert a page number at the current cursor position.
+N> Currently, the DOCX Editor has an option to insert a page number at the current cursor position.
 
 The following example code illustrates how to insert a page number in the header.
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/insert-text-in-current-position.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/insert-text-in-current-position.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Insert Content at Cursor in Blazor DOCX Editor | Syncfusion
 description: Insert text, paragraphs, and rich-text content in the current cursor position in Syncfusion® Blazor DOCX Editor control, its elements and more.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/move-selection-to-specific-position.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/move-selection-to-specific-position.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Move Selection to a Position in Blazor DOCX Editor | Syncfusion
 description: Move the document selection to a specific position in Syncfusion® Blazor DOCX Editor using APIs for precise navigation and content editing.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/optimize-sfdt.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/optimize-sfdt.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Optimize SFDT Files in Blazor DOCX Editor | Syncfusion
 description: Optimize SFDT files in Syncfusion® Blazor DOCX Editor to reduce file size, improve performance, and enhance document loading and processing efficiency.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/read-only-default.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/read-only-default.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Open Blazor DOCX Editor in Read-Only Mode | Syncfusion
 description: Open Syncfusion® Blazor DOCX Editor in read-only mode to prevent document modifications while allowing users to view content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -60,4 +60,4 @@ The following code example illustrates how to open a document in read-only mode.
     }
 }
 ```
-N> Use the [`RestrictEditing`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_RestrictEditing) property in the Document Editor Container or [`IsReadOnly`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_IsReadOnly) property in the Document Editor to change the component to read-only mode based on your requirement.
+N> Use the [`RestrictEditing`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_RestrictEditing) property in the Document Editor Container or [`IsReadOnly`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_IsReadOnly) property in the DOCX Editor to change the component to read-only mode based on your requirement.

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/resize-document-editor.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/resize-document-editor.md
@@ -3,40 +3,40 @@ layout: post
 title: How to Resize in Blazor DOCX Editor | Syncfusion
 description: Adjust the height and width of the Syncfusion® Blazor DOCX Editor to create responsive layouts and customize the document editing experience.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # How to Resize in Blazor DOCX Editor 
 
-In this article, we are going to see how to change the height and width of the Document Editor.
+In this article, we are going to see how to change the height and width of the DOCX Editor.
 
-## Change height of Document Editor
+## Change height of DOCX Editor
 
-[`Blazor Document Editor`](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) component initially renders with a default height. You can change the height of the Document Editor using the [`Height`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_Height) property; the value is in pixels.
+[`Blazor DOCX Editor`](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) component initially renders with a default height. You can change the height of the DOCX Editor using the [`Height`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_Height) property; the value is in pixels.
 
-The following example code illustrates how to change the height of the Document Editor.
+The following example code illustrates how to change the height of the DOCX Editor.
 
 ```csharp
 <SfDocumentEditorContainer @ref="container" EnableToolbar="true" Height="590px">
 </SfDocumentEditorContainer>
 ```
 
-Similarly, you can use the [`Height`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_Height) property for the Document Editor also.
+Similarly, you can use the [`Height`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_Height) property for the DOCX Editor also.
 
-## Change width of Document Editor
+## Change width of DOCX Editor
 
-Blazor Document Editor initially renders with a default width. You can change the width of the Document Editor using the [`Width`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_Width) property; the value is in percent.
+Blazor DOCX Editor initially renders with a default width. You can change the width of the DOCX Editor using the [`Width`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_Width) property; the value is in percent.
 
-The following example code illustrates how to change the width of the Document Editor.
+The following example code illustrates how to change the width of the DOCX Editor.
 
 ```csharp
 <SfDocumentEditorContainer @ref="container" EnableToolbar="true" Height="590px" Width="80%">
 </SfDocumentEditorContainer>
 ```
 
-Similarly, you can use the [`Width`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_Width) property for the Document Editor also.
+Similarly, you can use the [`Width`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_Width) property for the DOCX Editor also.
 
-## Resize Document Editor
+## Resize DOCX Editor
 
-Using the [`ResizeAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_ResizeAsync_System_Nullable_System_Double__System_Nullable_System_Double__) method, you can change the height and width of the Document Editor.
+Using the [`ResizeAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditorContainer.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditorContainer_ResizeAsync_System_Nullable_System_Double__System_Nullable_System_Double__) method, you can change the height and width of the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/retrieve-the-bookmark-content-as-text.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/retrieve-the-bookmark-content-as-text.md
@@ -3,19 +3,19 @@ layout: post
 title: How to Retrieve Bookmark Content in Blazor DOCX Editor | Syncfusion
 description: Retrieve bookmark content as plain text and retrieve document data in SFDT format using Syncfusion® Blazor DOCX Editor.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # How to Retrieve Bookmark Content as Text in Blazor DOCX Editor
 
-## How to retrieve the whole document and bookmark content as text in Blazor Document Editor
+## How to retrieve the whole document and bookmark content as text in Blazor DOCX Editor
 
 The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) component allows retrieving the bookmark or whole document content as plain text and SFDT (rich text).
 
 ## Get the bookmark content as plain text
 
-Use the [`SelectBookmarkAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectBookmarkAsync_System_String_) API to navigate to the bookmark and use [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the bookmark content as plain text from Blazor Document Editor component.
+Use the [`SelectBookmarkAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_SelectBookmarkAsync_System_String_) API to navigate to the bookmark and use [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the bookmark content as plain text from Blazor DOCX Editor component.
 
 The following example code illustrates how to get the bookmark content as plain text.
 
@@ -49,7 +49,7 @@ To get the bookmark content as SFDT (rich text), see [Get the selected content a
 
 ## Get the whole document content as text
 
-The [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API can be used to get the whole document content as plain text from the Blazor Document Editor component.
+The [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API can be used to get the whole document content as plain text from the Blazor DOCX Editor component.
 
 The following example code illustrates how to get the whole document content as plain text.
 
@@ -77,7 +77,7 @@ The following example code illustrates how to get the whole document content as 
 
 ## Get the whole document content as SFDT (Rich Text)
 
-The [`SerializeAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_SerializeAsync) API is used to get the whole document content as an SFDT string from the Blazor Document Editor component.
+The [`SerializeAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_SerializeAsync) API is used to get the whole document content as an SFDT string from the Blazor DOCX Editor component.
 
 The following example code illustrates how to get the whole document content as SFDT.
 
@@ -103,7 +103,7 @@ The following example code illustrates how to get the whole document content as 
 
 ## Get the header content as text
 
-Use the [`GoToHeaderAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GoToHeaderAsync) API to navigate the selection to the header and then use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the content as plain text from the Blazor Document Editor component.
+Use the [`GoToHeaderAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GoToHeaderAsync) API to navigate the selection to the header and then use the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the content as plain text from the Blazor DOCX Editor component.
 
 The following example code illustrates how to get the header content as plain text.
 
@@ -130,4 +130,4 @@ The following example code illustrates how to get the header content as plain te
 }
 ```
 
-Similarly, the [`GoToFooterAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GoToFooterAsync) API can be used to navigate the selection to the footer, followed by the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the content as plain text from the Blazor Document Editor component.
+Similarly, the [`GoToFooterAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GoToFooterAsync) API can be used to navigate the selection to the footer, followed by the [`GetTextAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SelectionModule.html#Syncfusion_Blazor_DocumentEditor_SelectionModule_GetTextAsync) API to get the content as plain text from the Blazor DOCX Editor component.

--- a/Document-Processing/Word/Word-Processor/blazor/how-to/show-hide-spinner.md
+++ b/Document-Processing/Word/Word-Processor/blazor/how-to/show-hide-spinner.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Show and Hide Spinner in Blazor DOCX Editor | Syncfusion
 description: Show or hide loading indicators in Syncfusion® Blazor DOCX Editor when opening documents and processing content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/image.md
+++ b/Document-Processing/Word/Word-Processor/blazor/image.md
@@ -3,7 +3,7 @@ layout: post
 title: Images in Blazor DOCX Editor | Syncfusion
 description: Images in Blazor DOCX Editor enable resizing and text wrapping while preserving image positions for accurate document layouts.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -19,13 +19,13 @@ Image files are internally converted to a base64 string. However, online images 
 
 ## Image resizing
 
-The Document Editor provides a built-in image resizer that can be injected into your application based on the requirements. This allows the image to be resized by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
+The DOCX Editor provides a built-in image resizer that can be injected into your application based on the requirements. This allows the image to be resized by dragging the resizing points using mouse or touch interactions. This resizer appears as follows.
 
-![Image Resizing in Blazor Document Editor](images/blazor-document-editor-image-resizing.jpeg)
+![Image Resizing in Blazor DOCX Editor](images/blazor-document-editor-image-resizing.jpeg)
 
 ## Changing size
 
-The Document Editor exposes APIs to get or resize the selected image. Width and height values are in points. Refer to the following sample code.
+The DOCX Editor exposes APIs to get or resize the selected image. Width and height values are in points. Refer to the following sample code.
 
 ```csharp
 int height = await container.DocumentEditor.Selection.ImageFormat.GetHeightAsync();
@@ -39,6 +39,6 @@ Text wrapping refers to how images fit with surrounding text in a document. [Ref
 
 ## Positioning the image
 
-The Document Editor preserves the position properties of the image and displays the image based on the position properties. It does not support modifying the position properties. However, the image will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
+The DOCX Editor preserves the position properties of the image and displays the image based on the position properties. It does not support modifying the position properties. However, the image will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
 
-You can also explore our [`Blazor Word Processor`](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to know how to render and configure the document editor.
+You can also explore our [`Blazor Word Processor`](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to know how to render and configure the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/link.md
+++ b/Document-Processing/Word/Word-Processor/blazor/link.md
@@ -3,7 +3,7 @@ layout: post
 title: Hyperlinks in Blazor DOCX Editor | Syncfusion
 description: The hyperlink feature in Blazor DOCX Editor enables users to insert, edit, and manage hyperlinks for quick navigation to web pages or document locations.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -21,7 +21,7 @@ Setting `args.IsHandled = true` prevents the editor's default navigation action 
 
 ### Add the OnRequestNavigate event for DocumentEditor
 
-The following example illustrates how to add the `OnRequestNavigate` event for the Document Editor.
+The following example illustrates how to add the `OnRequestNavigate` event for the DOCX Editor.
 
 ```cshtml
 <SfDocumentEditor ID="cont" IsReadOnly="false" EnableEditor="true" EnableSelection="true" @ref="container" Height="590px">
@@ -75,7 +75,7 @@ await container.DocumentEditor.Selection.CopyHyperlinkAsync();
 
 ## Add hyperlink
 
-The Document Editor can automatically format a URL as a hyperlink. Simply type an address and press `ENTER`, `SPACEBAR`, or `TAB`. The text will be converted to a functional hyperlink if it begins with one of the following prefixes:
+The DOCX Editor can automatically format a URL as a hyperlink. Simply type an address and press `ENTER`, `SPACEBAR`, or `TAB`. The text will be converted to a functional hyperlink if it begins with one of the following prefixes:
 
 *   `http://`
 *   `https://`
@@ -120,4 +120,4 @@ You can use the following keyboard shortcut to open the hyperlink dialog if the 
 
 ## Online demo
 
-Explore how to insert and manage hyperlinks in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/hyperlinks-and-bookmarks?theme=fluent2).
+Explore how to insert and manage hyperlinks in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/hyperlinks-and-bookmarks?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/list-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/list-format.md
@@ -3,7 +3,7 @@ layout: post
 title: List Format in Blazor DOCX Editor | Syncfusion
 description: The list format feature in Blazor DOCX Editor enables users to create and customize bulleted and numbered lists for organized document content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -54,14 +54,14 @@ await container.DocumentEditor.Editor.ClearListAsync();
 
 ## Editing numbered lists
 
-The Document Editor provides options for controlling the sequence of numbered lists.
+The DOCX Editor provides options for controlling the sequence of numbered lists.
 
 ### Restarting and continuing numbering
 
 When working with numbered lists, you can choose to restart numbering at "1" or continue the sequence from a previous list. These options are available in the context menu when you right-click a list number.
 
-![Context menu in Blazor Document Editor showing options to restart or continue list numbering.](images/blazor-document-editor-list.jpeg)
+![Context menu in Blazor DOCX Editor showing options to restart or continue list numbering.](images/blazor-document-editor-list.jpeg)
 
 ## Online demo
 
-Explore how to apply bullets and numbering in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/bullets-and-numbering?theme=fluent2).
+Explore how to apply bullets and numbering in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/bullets-and-numbering?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/mcp.md
+++ b/Document-Processing/Word/Word-Processor/blazor/mcp.md
@@ -16,7 +16,7 @@ These tools speed up development and reinforce best practices for Blazor DOCX Ed
 
 ## Key Benefits
 
-- **Expert DOCX Editor Knowledge** - Deep understanding of Blazor DOCX Editor component (Document Editor) and its implementation patterns.
+- **Expert DOCX Editor Knowledge** - Deep understanding of Blazor DOCX Editor component (DOCX Editor) and its implementation patterns.
 - **Unlimited Usage** - No request limits, time restrictions, or query caps.
 - **Privacy-Focused** - The tools operate based on the user's query and do not store any content, data, or prompts.
 

--- a/Document-Processing/Word/Word-Processor/blazor/opening-a-document.md
+++ b/Document-Processing/Word/Word-Processor/blazor/opening-a-document.md
@@ -3,7 +3,7 @@ layout: post
 title: Opening a Document in Blazor DOCX Editor | Syncfusion
 description: Open Word documents in Blazor DOCX Editor from URLs, cloud storage, databases, local files, or during component initialization.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ You might need to open and view Word documents from various locations. In this s
 
 ## Opening a document from URL
 
-If you have your Word document file in the web, you can open it in [Blazor Document Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) using a URL. The following code example explains how to open a Word document file from a URL.
+If you have your Word document file in the web, you can open it in [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) using a URL. The following code example explains how to open a Word document file from a URL.
 
 ```cshtml
 @using Syncfusion.Blazor.DocumentEditor
@@ -60,7 +60,7 @@ N> As per the discussion thread [#30064](https://github.com/dotnet/aspnetcore/is
 
 You can open the Word documents from cloud storage. The following code example shows how to open and load the Word document file stored in Azure Blob Storage.
 
-To open and save a document from the cloud quickly with the Blazor Document Editor component, you can check the video below.
+To open and save a document from the cloud quickly with the Blazor DOCX Editor component, you can check the video below.
 
 {% youtube "https://www.youtube.com/watch?v=sVINSXKPM4E" %}
 
@@ -290,11 +290,11 @@ The Word document can be opened on control initialization, in this sample, the d
 }
 ```
 
-You can also explore our [Blazor Word Processor](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to see how to render and configure the document editor.
+You can also explore our [Blazor Word Processor](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to see how to render and configure the DOCX Editor.
 
 ## Opening a document with TIFF, EMF and WMF images
 
-Web browsers do not support displaying metafile images like EMF and WMF and TIFF format images. As a fallback approach, you can convert the metafile/TIFF format image to a raster image using any image converter in the `MetafileImageParsed` event and this fallback raster image will be displayed in the client-side Document Editor component.
+Web browsers do not support displaying metafile images like EMF and WMF and TIFF format images. As a fallback approach, you can convert the metafile/TIFF format image to a raster image using any image converter in the `MetafileImageParsed` event and this fallback raster image will be displayed in the client-side DOCX Editor component.
 
 N> In the `MetafileImageParsedEventArgs` event argument, you can get the metafile stream using the `MetafileStream` property and you can get the `IsMetafile` boolean value to determine whether the image is a metafile (WMF, EMF) or a TIFF format image. In the example below, we have converted the TIFF to a raster image in the `ConvertTiffToRasterImage()` method using `BitMiracle https://www.nuget.org/packages/BitMiracle.LibTiff.NET`.
 

--- a/Document-Processing/Word/Word-Processor/blazor/overview.md
+++ b/Document-Processing/Word/Word-Processor/blazor/overview.md
@@ -3,7 +3,7 @@ layout: post
 title: About Syncfusion Blazor DOCX Editor Control | Syncfusion
 description: Learn about the introduction of Syncfusion Essential Studio Blazor DOCX Editor control and more details.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,7 +11,7 @@ documentation: ug
 
 The [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) is a feature-rich, user-interactive component that enables you to create, edit, view, and print Word documents with advanced formatting, editing capabilities, and broad support for document import and export formats.
 
-![Output of Blazor Document Editor](./images/docx-editor.png)
+![Output of Blazor DOCX Editor](./images/docx-editor.png)
 
 ## Key Features
 

--- a/Document-Processing/Word/Word-Processor/blazor/paragraph-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/paragraph-format.md
@@ -3,7 +3,7 @@ layout: post
 title: Paragraph Format in Blazor DOCX Editor | Syncfusion
 description: The paragraph format feature in Blazor DOCX Editor enables users to customize alignment, indentation, spacing, and layout for well-structured content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -81,7 +81,7 @@ await documentEditor.Selection.ParagraphFormat.SetAfterSpacingAsync(24);
 
 ## Show or hide paragraph marks
 
-You can show or hide the hidden formatting symbols like spaces, tab, paragraph marks, and breaks in the Document Editor component. These marks help identify the start and end of paragraphs and all the hidden formatting symbols in a Word document.
+You can show or hide the hidden formatting symbols like spaces, tab, paragraph marks, and breaks in the DOCX Editor component. These marks help identify the start and end of paragraphs and all the hidden formatting symbols in a Word document.
 
 The following example code illustrates how to show or hide paragraph marks.
 
@@ -97,4 +97,4 @@ The following example code illustrates how to show or hide paragraph marks.
 
 ## Online demo
 
-Explore how to apply paragraph formatting in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/paragraph-format?theme=fluent2).
+Explore how to apply paragraph formatting in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/paragraph-format?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/print.md
+++ b/Document-Processing/Word/Word-Processor/blazor/print.md
@@ -3,13 +3,13 @@ layout: post
 title: Print in Blazor DOCX Editor | Syncfusion
 description: Print feature in Blazor DOCX Editor enables printing documents with page setup and quality settings for accurate document output.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # Print in Blazor DOCX Editor
 
-To print the document, use the [`PrintAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_PrintAsync) method on the Document Editor instance.
+To print the document, use the [`PrintAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.SfDocumentEditor.html#Syncfusion_Blazor_DocumentEditor_SfDocumentEditor_PrintAsync) method on the DOCX Editor instance.
 
 Refer to the following example to print a document.
 
@@ -30,7 +30,7 @@ Refer to the following example to print a document.
 
 ## Improving print quality
 
-The Document Editor provides an option to improve the print quality using [`PrintDevicePixelRatio`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_PrintDevicePixelRatio) in the Document Editor settings. The Document Editor uses a canvas approach to render content. Then, the canvas is converted to an image and processed for printing. Using the [`PrintDevicePixelRatio`] API, the image quality can be increased based on specific requirements.
+The DOCX Editor provides an option to improve the print quality using [`PrintDevicePixelRatio`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_PrintDevicePixelRatio) in the Document Editor settings. The DOCX Editor uses a canvas approach to render content. Then, the canvas is converted to an image and processed for printing. Using the [`PrintDevicePixelRatio`] API, the image quality can be increased based on specific requirements.
 
 The following example code illustrates how to improve the print quality in the Document Editor container.
 

--- a/Document-Processing/Word/Word-Processor/blazor/restrict-editing.md
+++ b/Document-Processing/Word/Word-Processor/blazor/restrict-editing.md
@@ -3,7 +3,7 @@ layout: post
 title: Restrict Editing in Blazor DOCX Editor | Syncfusion
 description: Restrict editing feature in Blazor DOCX Editor enables read-only access, form filling, comments, and editable regions to protect document content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -80,4 +80,4 @@ The following code example demonstrates how to enable or disable editable region
 
 ## Online Demo
 
-Explore how to restrict editing and protect Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/document-protection?theme=fluent2).
+Explore how to restrict editing and protect Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/document-protection?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/saving-document.md
+++ b/Document-Processing/Word/Word-Processor/blazor/saving-document.md
@@ -3,7 +3,7 @@ layout: post
 title: Saving a Document in Blazor DOCX Editor | Syncfusion
 description: Save documents from Blazor DOCX Editor to a server, database, or local file system, and download document copies in supported formats
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 

--- a/Document-Processing/Word/Word-Processor/blazor/section-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/section-format.md
@@ -3,7 +3,7 @@ layout: post
 title: Section Format in Blazor DOCX Editor | Syncfusion
 description: The section format feature in Blazor DOCX Editor enables users to customize page layout, margins, orientation, and section-specific settings.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -35,7 +35,7 @@ await documentEditor.Selection.SectionFormat.SetTopMarginAsync(10);
 await documentEditor.Selection.SectionFormat.SetBottomMarginAsync(10);
 ```
 
-N> The maximum value of `Margin` is 1584, as per the Microsoft Word application, and you can set any value less than or equal to 1584 to this property. If you set any value greater than 1584, then the Syncfusion Document Editor will automatically reset it to 1584.
+N> The maximum value of `Margin` is 1584, as per the Microsoft Word application, and you can set any value less than or equal to 1584 to this property. If you set any value greater than 1584, then the Syncfusion DOCX Editor will automatically reset it to 1584.
 
 ## Header distance
 
@@ -55,4 +55,4 @@ await documentEditor.Selection.SectionFormat.SetFooterDistanceAsync(72);
 
 ## Online demo
 
-Explore how to apply section formatting in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/section-format?theme=fluent2).
+Explore how to apply section formatting in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/section-format?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/shapes.md
+++ b/Document-Processing/Word/Word-Processor/blazor/shapes.md
@@ -3,7 +3,7 @@ layout: post
 title: Shapes in Blazor DOCX Editor | Syncfusion
 description: The shapes feature in Blazor DOCX Editor preserve shape elements, text boxes, resizing, positioning, and text wrapping for accurate document rendering.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,9 +13,9 @@ Shapes are drawing objects that include a text box, rectangles, lines, curves, c
 
 ## Supported shapes
 
-The Document Editor has preservation support for Lines, Rectangles, Basic Shapes, Block Arrows, Equation Shapes, Flowchart, and Stars and Banners.
+The DOCX Editor has preservation support for Lines, Rectangles, Basic Shapes, Block Arrows, Equation Shapes, Flowchart, and Stars and Banners.
 
-![List of supported shapes in Document Editor](images/Shapes_images/supported_shapes.png)
+![List of supported shapes in DOCX Editor](images/Shapes_images/supported_shapes.png)
 
 N> When using ASP.NET MVC service, the unsupported shapes will be converted as image and preserved as image.
 
@@ -23,13 +23,13 @@ N> When using ASP.NET MVC service, the unsupported shapes will be converted as i
 
 A text box is a rectangular area on the document where you can enter text. Clicking in a text box displays a flashing cursor, indicating that text can be entered. It allows you to enter multiple lines of text with all text formatting.
 
-![Text box shape view in Document Editor](images/Shapes_images/textbox_shape.png)
+![Text box shape view in DOCX Editor](images/Shapes_images/textbox_shape.png)
 
 ## Shape resizer
 
-The Document Editor also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer accepts both touch and mouse interactions.
+The DOCX Editor also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer accepts both touch and mouse interactions.
 
-![Shape resizer view in Document Editor](images/Shapes_images/shape_resizer.png)
+![Shape resizer view in DOCX Editor](images/Shapes_images/shape_resizer.png)
 
 ## Text wrapping style
 
@@ -37,8 +37,8 @@ Text wrapping refers to how shapes fit with surrounding text in a document. [Ref
 
 ## Positioning the shape
 
-The Document Editor preserves the position properties of the shape and displays the shape based on the position properties. It does not support modifying the position properties. However, the shape will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
+The DOCX Editor preserves the position properties of the shape and displays the shape based on the position properties. It does not support modifying the position properties. However, the shape will be automatically moved along with the text edited if it is positioned relative to the line or paragraph.
 
 ## Online demo
 
-Explore how to preserve AutoShapes in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/autoshapes?theme=fluent2).
+Explore how to preserve AutoShapes in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/autoshapes?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/styles.md
+++ b/Document-Processing/Word/Word-Processor/blazor/styles.md
@@ -3,7 +3,7 @@ layout: post
 title: Styles in Blazor DOCX Editor | Syncfusion
 description: The styles feature in Blazor DOCX Editor enables users to apply, customize, and manage consistent formatting across document content.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ Styles are useful for applying a set of formatting consistently throughout the d
 
 ## Styles definition overview
 
-A style in the Document Editor should have the following properties:
+A style in the DOCX Editor should have the following properties:
 
 * **name**: Name of the style. All styles in a document have a unique name, which is used as an identifier when applying the style.
 * **type**: Specifies the document elements that the style will target. For example, paragraph or character.
@@ -27,7 +27,7 @@ N> The style type should match the inherited style type. For example, it is not 
 
 ## Default style
 
-The default style for span and paragraph properties is `Normal`. It internally inherits the default style of the document loaded or the Document Editor component.
+The default style for span and paragraph properties is `Normal`. It internally inherits the default style of the document loaded or the DOCX Editor component.
 
 ## Style hierarchy
 
@@ -158,4 +158,4 @@ object characterStyles = await container.DocumentEditor.GetStylesAsync(StyleType
 
 ## Online demo
 
-Explore how to apply and modify styles in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/styles?theme=fluent2).
+Explore how to apply and modify styles in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/styles?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/supported-fileformats.md
+++ b/Document-Processing/Word/Word-Processor/blazor/supported-fileformats.md
@@ -14,7 +14,7 @@ domainurl: ##DomainURL##
 
 ## Supported file formats
 
-The following table describes the supported formats and their conversion capabilities in the Document Editor.
+The following table describes the supported formats and their conversion capabilities in the DOCX Editor.
 
 | File Format | Open | Export |
 |-------------|------|--------|

--- a/Document-Processing/Word/Word-Processor/blazor/table-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/table-format.md
@@ -3,7 +3,7 @@ layout: post
 title: Table Format in Blazor DOCX Editor | Syncfusion
 description: The table format feature in Blazor DOCX Editor enables customizing cell margins, spacing, alignment, borders, and sizing to create structured tables.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -71,7 +71,7 @@ await documentEditor.Selection.CellFormat.SetVerticalAlignmentAsync(CellVertical
 
 ## Table alignment
 
-The tables are aligned in the Document Editor to `Left`, `Right`, or `Center`. Refer to the following sample code.
+The tables are aligned in the DOCX Editor to `Left`, `Right`, or `Center`. Refer to the following sample code.
 
 ```csharp
 await documentEditor.Selection.TableFormat.SetTableAlignmentAsync(TableAlignment.Center);
@@ -121,7 +121,7 @@ You can set the desired width of a table in `Point` or `Percent` type. Refer to 
 
 ## Working with row formatting
 
-The Document Editor supports various row formatting options such as height and repeat header.
+The DOCX Editor supports various row formatting options such as height and repeat header.
 
 ## Row height
 
@@ -162,7 +162,7 @@ await documentEditor.Selection.RowFormat.SetAllowBreakAcrossPagesAsync(false);
 
 ### Title
 
-The Document Editor exposes API to get or set the table title of the selected table. Refer to the following sample code to set the title.
+The DOCX Editor exposes API to get or set the table title of the selected table. Refer to the following sample code to set the title.
 
 ```csharp
 await documentEditor.Selection.TableFormat.SetTitleAsync("Shipping Details");
@@ -170,7 +170,7 @@ await documentEditor.Selection.TableFormat.SetTitleAsync("Shipping Details");
 
 ### Description
 
-The Document Editor exposes API to get or set the table description of the selected table. Refer to the following sample code to set the description.
+The DOCX Editor exposes API to get or set the table description of the selected table. Refer to the following sample code to set the description.
 
 ```csharp
 await documentEditor.Selection.TableFormat.SetDescriptionAsync("Freight cost and shipping details");
@@ -178,4 +178,4 @@ await documentEditor.Selection.TableFormat.SetDescriptionAsync("Freight cost and
 
 ## Online demo
 
-Explore how to format tables in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/table-format?theme=fluent2).
+Explore how to format tables in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/table-format?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/table-of-contents.md
+++ b/Document-Processing/Word/Word-Processor/blazor/table-of-contents.md
@@ -3,7 +3,7 @@ layout: post
 title: Table of Contents in Blazor DOCX Editor | Syncfusion
 description: The Table of Contents feature in Blazor DOCX Editor enables users to generate and update a structured index for quick document navigation.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ The table of contents in a document is the same as the list of chapters at the b
 
 ## Inserting table of contents
 
-Blazor Document Editor exposes an API to insert a table of contents at the cursor position programmatically. The settings for a table of contents can be specified explicitly. Otherwise, the default settings are applied.
+Blazor DOCX Editor exposes an API to insert a table of contents at the cursor position programmatically. The settings for a table of contents can be specified explicitly. Otherwise, the default settings are applied.
 
 [`TableOfContentsSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.TableOfContentsSettings.html) contain the following properties:
 * **startLevel**: Specifies the start level for constructing a table of contents.
@@ -24,7 +24,7 @@ Blazor Document Editor exposes an API to insert a table of contents at the curso
 * **tabLeader**: Specifies the tab leader styles such as `None`, `Dot`, `Hyphen`, and `Underscore`.
 * **includeOutlineLevels**: Specifies whether the outline levels are included.
 
-The following code illustrates how to insert a table of contents in the Document Editor.
+The following code illustrates how to insert a table of contents in the DOCX Editor.
 
 ```csharp
 TableOfContentsSettings tableOfContentsSettings = new TableOfContentsSettings();
@@ -65,7 +65,7 @@ await editor.Editor.InsertTableOfContentsAsync(tableOfContentsSettings);
 
 You can update or edit the table of contents using the built-in context menu shown when you right-click it. Refer to the following screenshot.
 
-![Updating Table Contents in Blazor Document Editor](images/blazor-documenteditor-table-contents.jpeg)
+![Updating Table Contents in Blazor DOCX Editor](images/blazor-documenteditor-table-contents.jpeg)
 
 * **Update Field**: Updates the headings in the table of contents with the same settings by searching the entire document.
 * **Edit Field**: Opens the built-in table of contents dialog and allows you to modify its settings.
@@ -88,4 +88,4 @@ N> The same method is used for inserting, updating, and editing the table of con
 
 ## Online demo
 
-Explore how to insert and update table of contents in Word documents using the Blazor Document Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/table-of-contents?theme=fluent2).
+Explore how to insert and update table of contents in Word documents using the Blazor DOCX Editor in this [live demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/table-of-contents?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/table.md
+++ b/Document-Processing/Word/Word-Processor/blazor/table.md
@@ -3,13 +3,13 @@ layout: post
 title: Tables in Blazor DOCX Editor | Syncfusion
 description: Tables in Blazor DOCX Editor enable adding and managing rows, columns, and cells to present information in a structured format.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # Tables in Blazor DOCX Editor
 
-Tables are an efficient way to present information. The Document Editor can display and edit tables. You can select and edit tables through a keyboard, mouse, or touch interactions. [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) exposes a rich set of APIs to perform these operations programmatically.
+Tables are an efficient way to present information. The DOCX Editor can display and edit tables. You can select and edit tables through a keyboard, mouse, or touch interactions. [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor) exposes a rich set of APIs to perform these operations programmatically.
 
 ## Create a table
 
@@ -101,7 +101,7 @@ await documentEditor.Selection.SelectCellAsync();
 
 ## Delete table
 
-The Document Editor allows you to delete the entire table. You can use the [`DeleteTableAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteTableAsync) method of the editor instance, if the selection is in a table. Refer to the following sample code.
+The DOCX Editor allows you to delete the entire table. You can use the [`DeleteTableAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteTableAsync) method of the editor instance, if the selection is in a table. Refer to the following sample code.
 
 ```csharp
 await documentEditor.Editor.DeleteTableAsync();
@@ -109,7 +109,7 @@ await documentEditor.Editor.DeleteTableAsync();
 
 ## Delete row
 
-The Document Editor allows you to delete the selected number of rows. You can use the [`DeleteRowAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteRowAsync) method of the editor instance to delete the selected number of rows, if the selection is in a table. Refer to the following sample code.
+The DOCX Editor allows you to delete the selected number of rows. You can use the [`DeleteRowAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteRowAsync) method of the editor instance to delete the selected number of rows, if the selection is in a table. Refer to the following sample code.
 
 ```csharp
 await documentEditor.Editor.DeleteRowAsync();
@@ -117,7 +117,7 @@ await documentEditor.Editor.DeleteRowAsync();
 
 ## Delete column
 
-The Document Editor allows you to delete the selected number of columns. You can use the [`DeleteColumnAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteColumnAsync) method of the editor instance to delete the selected number of columns, if the selection is in a table. Refer to the following sample code.
+The DOCX Editor allows you to delete the selected number of columns. You can use the [`DeleteColumnAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_DeleteColumnAsync) method of the editor instance to delete the selected number of columns, if the selection is in a table. Refer to the following sample code.
 
 ```csharp
 await documentEditor.Editor.DeleteColumnAsync();
@@ -132,4 +132,4 @@ Refer to the following sample code.
 await documentEditor.Editor.MergeCellsAsync();
 ```
 
-You can also explore our [Blazor Document Editor](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to know how to render and configure the Document Editor.
+You can also explore our [Blazor DOCX Editor](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/default-functionalities) example to know how to render and configure the DOCX Editor.

--- a/Document-Processing/Word/Word-Processor/blazor/text-format.md
+++ b/Document-Processing/Word/Word-Processor/blazor/text-format.md
@@ -3,7 +3,7 @@ layout: post
 title: Text Format in Blazor DOCX Editor | Syncfusion
 description: Text format properties in Blazor DOCX Editor enables customizing text appearance with font styles, colors, highlighting, and character formatting options.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -128,7 +128,7 @@ await documentEditor.Selection.CharacterFormat.SetFontSizeAsync(32);
 
 ### Change Font Color by UI Option
 
-In the Document Editor, the Text Properties pane features two icons for managing text color within the user interface (UI):
+In the DOCX Editor, the Text Properties pane features two icons for managing text color within the user interface (UI):
 
 * **Colored Box:** This icon visually represents the **current color** applied to the selected text.
 * **Text (A) Icon:** Clicking this icon allows users **to modify the color** of the selected text by choosing a new color from the available options.
@@ -164,4 +164,4 @@ await documentEditor.Selection.CharacterFormat.SetHighlightColorAsync(HighlightC
 
 ## Online Demo
 
-Explore how to apply text formatting in Word documents using the Blazor Document Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/character-format?theme=fluent2).
+Explore how to apply text formatting in Word documents using the Blazor DOCX Editor in this live demo [here](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/character-format?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/text-wrapping-style.md
+++ b/Document-Processing/Word/Word-Processor/blazor/text-wrapping-style.md
@@ -3,7 +3,7 @@ layout: post
 title: Text Wrapping Style in Blazor DOCX Editor | Syncfusion
 description: Text wrapping styles in Blazor DOCX Editor preserve inline, square, behind text, and other wrapping modes during document rendering.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -15,13 +15,13 @@ Text wrapping refers to how images and shapes are fit with surrounding text in a
 
 In this option, the image or shape is placed inline with the surrounding text like any other word or letter. This image or shape will be automatically moved along with the text while editing, whereas the other options keep the image or shape in a fixed position while the text shifts and wraps around it.
 
-![View of image with inline wrapping style in Document Editor](images/Text-Wrapping-Style_images/inline-textwrapping.PNG)
+![View of image with inline wrapping style in DOCX Editor](images/Text-Wrapping-Style_images/inline-textwrapping.PNG)
 
 ## In Front of text
 
 In this option, the image or shape is placed in front of the text. This can be used to place an image around some text or to add a shape to highlight a part in a paragraph.
 
-![View of image with in front of text wrapping style in Document Editor](images/Text-Wrapping-Style_images/infront-textwrapping.PNG)
+![View of image with in front of text wrapping style in DOCX Editor](images/Text-Wrapping-Style_images/infront-textwrapping.PNG)
 
 N> Starting from v18.2.0.x, the in-front-of-text wrapping style is supported.
 
@@ -31,13 +31,13 @@ In this option, the text wraps above and below the image or shape. No text appea
 
 N> Starting from v19.1.0.x, the top and bottom wrapping style is supported.
 
-![View of image with top and bottom wrapping style in Document Editor](images/Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
+![View of image with top and bottom wrapping style in DOCX Editor](images/Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
 
 ## Behind
 
 In this option, the image or shape is placed behind the text. This can be used when you need to add a watermark or background image to a document.
 
-![View of image with behind wrapping style in Document Editor](images/Text-Wrapping-Style_images/behind-textwrapping.PNG)
+![View of image with behind wrapping style in DOCX Editor](images/Text-Wrapping-Style_images/behind-textwrapping.PNG)
 
 N> Starting from v19.2.0.x, the behind text wrapping style is supported.
 
@@ -45,6 +45,6 @@ N> Starting from v19.2.0.x, the behind text wrapping style is supported.
 
 In this option, the text wraps around the image or text box in a square shape.
 
-N> Tight and Through styles will be preserved as the square wrapping style in Document Editor, which is supported from v19.2.0.x.
+N> Tight and Through styles will be preserved as the square wrapping style in DOCX Editor, which is supported from v19.2.0.x.
 
-![View of shape with square wrapping style in Document Editor](images/Text-Wrapping-Style_images/square-textwrapping.PNG)
+![View of shape with square wrapping style in DOCX Editor](images/Text-Wrapping-Style_images/square-textwrapping.PNG)

--- a/Document-Processing/Word/Word-Processor/blazor/track-changes.md
+++ b/Document-Processing/Word/Word-Processor/blazor/track-changes.md
@@ -3,7 +3,7 @@ layout: post
 title: Track Changes in Blazor DOCX Editor | Syncfusion
 description: Track changes in Blazor DOCX Editor records document modifications and enables reviewers to accept or reject revisions efficiently.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
@@ -11,7 +11,7 @@ documentation: ug
 
 Track Changes allows you to keep a record of changes or edits made to a document. You can then choose to accept or reject the modifications. It is a useful tool for managing changes made by several reviewers to the same document. If the track changes option is enabled, all editing operations are preserved as revisions in [Blazor DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/blazor-docx-editor) (Document Editor).
 
-## Enable track changes in Document Editor
+## Enable track changes in DOCX Editor
 
 The following example demonstrates how to enable track changes.
 
@@ -40,7 +40,7 @@ N> Track changes are document level settings. When opening a document, if the do
 
 ## Show or Hide revisions pane
 
-The Show or Hide Revisions Pane feature in the Document Editor allows users to toggle the visibility of the revisions pane, providing flexibility in managing tracked changes within the document.
+The Show or Hide Revisions Pane feature in the DOCX Editor allows users to toggle the visibility of the revisions pane, providing flexibility in managing tracked changes within the document.
 
 The following example code illustrates how to show or hide the revisions pane.
 
@@ -79,13 +79,13 @@ await container.DocumentEditor.Selection.NavigatePreviousRevisionAsync();
 
 ## Filter changes by user
 
-In the Document Editor, we have a built-in review panel in which we have provided support for filtering changes based on the user.
+In the DOCX Editor, we have a built-in review panel in which we have provided support for filtering changes based on the user.
 
-![Track changes in Blazor Document Editor](images/track-changes.png)
+![Track changes in Blazor DOCX Editor](images/track-changes.png)
 
 ## Add custom metadata with the author
 
-The Document Editor provides options to customize revisions using [`RevisionSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_RevisionSettings). The `CustomData` property allows you to attach additional metadata to tracked revisions in the Word Processor. This metadata can represent roles, tags, or any custom identifier for the revision. To display this metadata along with the author name in the Track Changes pane, you must enable the `ShowCustomDataWithAuthor` property.
+The DOCX Editor provides options to customize revisions using [`RevisionSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.DocumentEditorSettingsModel.html#Syncfusion_Blazor_DocumentEditor_DocumentEditorSettingsModel_RevisionSettings). The `CustomData` property allows you to attach additional metadata to tracked revisions in the Word Processor. This metadata can represent roles, tags, or any custom identifier for the revision. To display this metadata along with the author name in the Track Changes pane, you must enable the `ShowCustomDataWithAuthor` property.
 
 The following example code illustrates how to enable and update custom metadata for track changes revisions.
 
@@ -107,13 +107,13 @@ The Track Changes pane will display the author name along with the custom metada
 
 N> When you export the document as SFDT, the customData value is stored in the revision collection. When you reopen the SFDT, the custom data is automatically restored and displayed in the Track Changes pane.
 
-N> Other than SFDT export (e.g., DOCX and others), the customData is not preserved, as it is specific to the Document Editor component.
+N> Other than SFDT export (e.g., DOCX and others), the customData is not preserved, as it is specific to the DOCX Editor component.
 
 ## Protect the document in track changes only mode
 
-Document Editor provides support for protecting the document with `RevisionsOnly` protection. In this protection, users can view the document and make their corrections, but they cannot accept or reject any tracked changes in the document. Later, the author can view their corrections and accept or reject the changes.
+DOCX Editor provides support for protecting the document with `RevisionsOnly` protection. In this protection, users can view the document and make their corrections, but they cannot accept or reject any tracked changes in the document. Later, the author can view their corrections and accept or reject the changes.
 
-Document Editor provides an option to protect and unprotect the document using [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_) APIs.
+DOCX Editor provides an option to protect and unprotect the document using [`EnforceProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_EnforceProtectionAsync_System_String_Syncfusion_Blazor_DocumentEditor_ProtectionType_) and [`StopProtectionAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DocumentEditor.EditorModule.html#Syncfusion_Blazor_DocumentEditor_EditorModule_StopProtectionAsync_System_String_) APIs.
 
 The following example code illustrates how to enforce and stop protection in the Document Editor container.
 
@@ -143,4 +143,4 @@ N> In enforce Protection method, first parameter denotes password and second par
 
 ## Online demo
 
-Explore how to track and review changes in Word documents using the Blazor Document Editor in this live [Blazor Track Changes demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/track-changes?theme=fluent2).
+Explore how to track and review changes in Word documents using the Blazor DOCX Editor in this live [Blazor Track Changes demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/track-changes?theme=fluent2).

--- a/Document-Processing/Word/Word-Processor/blazor/ui-builder-skill.md
+++ b/Document-Processing/Word/Word-Processor/blazor/ui-builder-skill.md
@@ -152,7 +152,7 @@ To start using the skill:
 
 {% promptcard Dynamic Toolbar Customization Editor %}
 
-Build a new Blazor application with DOCX Editor. Include a sidebar panel on the right side that displays a list of toolbar options with checkboxes for New, Open, Undo and Redo. Add a button at the bottom of the panel labeled "Apply Changes". When users select or deselect the checkboxes and click the button, the toolbar at the top of the DOCX Editor should dynamically show or hide the corresponding items in real time, providing a customizable editing experience similar to advanced document editors. 
+Build a new Blazor application with DOCX Editor. Include a sidebar panel on the right side that displays a list of toolbar options with checkboxes for New, Open, Undo and Redo. Add a button at the bottom of the panel labeled "Apply Changes". When users select or deselect the checkboxes and click the button, the toolbar at the top of the DOCX Editor should dynamically show or hide the corresponding items in real time, providing a customizable editing experience similar to advanced DOCX Editors. 
 
 {% endpromptcard %}
 

--- a/Document-Processing/Word/Word-Processor/blazor/view.md
+++ b/Document-Processing/Word/Word-Processor/blazor/view.md
@@ -3,13 +3,13 @@ layout: post
 title: View in Blazor DOCX Editor | Syncfusion
 description: View in Blazor DOCX Editor enables web layout, ruler display, and heading navigation to enhance document readability and navigation.
 platform: document-processing
-control: Document Editor
+control: DOCX Editor
 documentation: ug
 ---
 
 # View in Blazor DOCX Editor
 
-This topic describes view-related options in the Document Editor, including layout type (Pages or Continuous), displaying the ruler, and enabling the heading navigation pane.
+This topic describes view-related options in the DOCX Editor, including layout type (Pages or Continuous), displaying the ruler, and enabling the heading navigation pane.
 
 ## Web layout
 
@@ -24,7 +24,7 @@ N> The default value of [`LayoutType`](https://help.syncfusion.com/cr/blazor/Syn
 
 ### Online demo
 
-Explore how to view Word documents in web layout using the Blazor Document Editor in this live [Blazor Web Layout demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/web-layout?theme=fluent2).
+Explore how to view Word documents in web layout using the Blazor DOCX Editor in this live [Blazor Web Layout demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/web-layout?theme=fluent2).
 
 ## Show ruler
 
@@ -46,13 +46,13 @@ The following example illustrates how to enable the ruler in the Document Editor
 
 ### Online demo
 
-Explore how to use the ruler in the Blazor Document Editor for working with Word documents in this live [Blazor Ruler demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/ruler?theme=fluent2).
+Explore how to use the ruler in the Blazor DOCX Editor for working with Word documents in this live [Blazor Ruler demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/ruler?theme=fluent2).
 
 ## Heading navigation pane
 
 Using the heading navigation pane allows users to quickly navigate documents by heading.
 
-The following example demonstrates how to enable the heading navigation pane in a Document Editor.
+The following example demonstrates how to enable the heading navigation pane in a DOCX Editor.
 
 ```csharp
 <SfDocumentEditorContainer @ref="container" Height="590px" DocumentEditorSettings="@settings">
@@ -66,4 +66,4 @@ The following example demonstrates how to enable the heading navigation pane in 
 
 ### Online demo
 
-Explore how to navigate through headings in Word documents using the Blazor Document Editor in this live [Blazor Heading Navigation demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/heading-navigation?theme=fluent2).
+Explore how to navigate through headings in Word documents using the Blazor DOCX Editor in this live [Blazor Heading Navigation demo](https://document.syncfusion.com/demos/docx-editor/blazor-server/document-editor/heading-navigation?theme=fluent2).


### PR DESCRIPTION
## Description 

Resolved redundant keyword usage in Blazor DOCX Editor.

Reduced the occurrences of "**_Document Editor_**" wherever possible, replacing it with "**_DOCX Editor_**" 


## Before
<img width="1171" height="860" alt="image" src="https://github.com/user-attachments/assets/7aa31e9f-dc1b-44e0-afa7-56557e9add77" />


## After
<img width="1186" height="860" alt="image" src="https://github.com/user-attachments/assets/29168e0a-2b54-481b-965b-1dbec2166459" />

## Final Data

The occurrence count of **80** is present in the following areas, which have been intentionally ignored:

1. "Document Editor" maintained within the brackets in the first paragraph of every UG page.
2. Document Editor Settings.
3. Document Editor Container.
4. Code blocks and code comments.

These occurrences were not modified because they are part of standard checklist content, feature names, container names, or code-related content.
