### PR TITLE
Task(1050024) - Resolved redundant keyword usage in WPF DOCX Editor

### DIFF
--- a/Document-Processing/Word/Word-Processor/wpf/Automatic-Suggestion.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Automatic-Suggestion.md
@@ -9,11 +9,11 @@ keywords: automatic-suggestion, @mentions
 # Automatic Suggestion in WPF DOCX Editor
 
 ## Automatic Suggestion functionality for using @mentions
-[WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) control shows an inline dropdown with a list of suggested names while typing the mention character (@ symbol). The list of suggested names filters as you type additional characters. You can use the up or down arrow keys to move the selection and the Tab or Enter key to insert the selected item. You can also use the mouse to click any option in the list. The selected item from the suggestion list will be inserted as hyperlink with the display text and its respective link.
+[WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) control shows an inline dropdown with a list of suggested names while typing the mention character (@ symbol). The list of suggested names filters as you type additional characters. You can use the up or down arrow keys to move the selection and the Tab or Enter key to insert the selected item. You can also use the mouse to click any option in the list. The selected item from the suggestion list will be inserted as hyperlink with the display text and its respective link.
 
-![WPF RichTextBox displays Automatic Suggestion](Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG)
+![WPF DOCX Editor displays Automatic Suggestion](Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG)
 
-The following sample code demonstrates how to use @mentions in RichTextBox.
+The following sample code demonstrates how to use @mentions in WPF DOCX Editor.
 {% tabs %}
 {% highlight xaml %}
 <Window.Resources>
@@ -106,7 +106,7 @@ N> [View example in GitHub](https://github.com/SyncfusionExamples/WPF-RichTextBo
 ## Customize the SuggestionBox ItemTemplate and Style
 By default, the drop-down window lists the filtered items as an image, display text and link. If you want to remove the image or link, you can write your own item template.
 
-![Modifying Suggestion Box Item in WPF RichTextBox](Automatic-Suggestion_images/wpf-richtextbox-modify-suggestion.PNG)
+![Modifying Suggestion Box Item in WPF DOCX Editor](Automatic-Suggestion_images/wpf-richtextbox-modify-suggestion.PNG)
 
 The following sample code demonstrates how to modify the suggestion box item template and style.
 {% tabs %}
@@ -207,7 +207,7 @@ richTextboxadv.SuggestionSettings.SuggestionProviders.Add(suggestionProvider);
 ## Custom mention character
 Any character can be used as a mention character, and the default value is @.
 
-![WPF RichTextBox with Custom Mention Character](Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG)
+![WPF DOCX Editor with Custom Mention Character](Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG)
 
 The following sample code demonstrates how to use ‘#’ as mention character.
 {% tabs %}
@@ -254,7 +254,7 @@ richTextboxadv.SuggestionSettings.SuggestionProviders.Add(suggestionProvider);
 ## Multiple Suggestion Providers
 Two or more suggestion providers can be used at a time, but each suggestion provider should have a different mention character. Additionally, each suggestion provider can have a different item source and suggestion box style.
 
-<table><tr><td><img src="Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG" alt="WPF RichTextBox displays Multiple Suggestion"/><br/></td><td><img src="Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG" alt="WPF RichTextBox displays Multiple Suggestion"/><br/></td></tr></table>
+<table><tr><td><img src="Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG" alt="WPF DOCX Editor displays Multiple Suggestion"/><br/></td><td><img src="Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG" alt="WPF DOCX Editor displays Multiple Suggestion"/><br/></td></tr></table>
 
 
 The following sample code demonstrates how to use two suggestion providers. Here we have used ‘@’ and ‘#’ as mention characters.
@@ -374,16 +374,16 @@ When the entered item is not in the suggestion list, the suggestion box displays
 
 To customize this message, follow these steps:
 •	Right click your project and add new folder named Resources.
-•	Add the [default resource file](https://github.com/syncfusion/wpf-controls-localization-resx-files/tree/master/Syncfusion.SfRichTextBoxAdv.WPF) of the RichTextBox control into the Resources folder.
+•	Add the [default resource file](https://github.com/syncfusion/wpf-controls-localization-resx-files/tree/master/Syncfusion.SfRichTextBoxAdv.WPF) of the WPF DOCX Editor control into the Resources folder.
 •	Modify the value of the `SuggestionBoxErrorMessage` resource key in the resource file.
 
 The following image illustrates the error message displayed when no matching suggestion is found.
 
-![WPF RichTextBox displays Message](Automatic-Suggestion_images/wpf-richtextbox-message.PNG)
+![WPF DOCX Editor displays Message](Automatic-Suggestion_images/wpf-richtextbox-message.PNG)
 
 The following image shows the default resource file used to modify the error message.
 
-![WPF RichTextBox displays Resource File](Automatic-Suggestion_images/wpf-richtextbox-resource-file.PNG)
+![WPF DOCX Editor displays Resource File](Automatic-Suggestion_images/wpf-richtextbox-resource-file.PNG)
 
 
 ## Custom suggestion provider
@@ -526,7 +526,7 @@ N> [View example in GitHub](https://github.com/SyncfusionExamples/WPF-RichTextBo
 
 By default, the suggestion list is filtered as you type using the `Contains` matching logic, meaning items whose `Name` contains the entered text are displayed. You can customize this behavior, such as showing only items whose names start with or end with the entered text, by implementing a custom suggestion provider and overriding the `Search` method.
 
-<table><tr><td>Default search – contains</td><td>Custom search – starts with</td></tr><tr><td><img src="Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG" alt="WPF RichTextBox displays Auto Suggestion"/></td><td><img src="Automatic-Suggestion_images/wpf-richtextbox-search.PNG" alt="Customizing Search Text in WPF RichTextBox"/></td></tr></table>
+<table><tr><td>Default search – contains</td><td>Custom search – starts with</td></tr><tr><td><img src="Automatic-Suggestion_images/wpf-richtextbox-auto-suggestion.PNG" alt="WPF DOCX Editor displays Auto Suggestion"/></td><td><img src="Automatic-Suggestion_images/wpf-richtextbox-search.PNG" alt="Customizing Search Text in WPF DOCX Editor"/></td></tr></table>
 
 The following sample code demonstrates how to override search operation in your suggestion provider.
 
@@ -550,7 +550,7 @@ public List<object> Search(string searchText)
 ## Customize insert item
 By default, the selected item from the suggestions list is inserted as a hyperlink. You can customize the insertion behavior—for example, to insert the selected item as plain text instead of a hyperlink—by implementing your own suggestion provider and overriding the `InsertSelectedItem` method.
 
-![WPF RichTextBox with Custom Insert Item](Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG)
+![WPF DOCX Editor with Custom Insert Item](Automatic-Suggestion_images/wpf-richtextbox-custom-mention-character.PNG)
 
 The following sample code demonstrates how to override the insert selected item operation in your suggestion provider. In this example, the selected item is inserted as plain text using `InsertText`, so no hyperlink is added. If you want to insert the item as a hyperlink, use the [InsertHyperlink](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SelectionAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SelectionAdv_InsertHyperlink_System_String_System_String_System_String_) API instead.
 

--- a/Document-Processing/Word/Word-Processor/wpf/Background.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Background.md
@@ -8,7 +8,7 @@ keywords: background
 ---
 
 # Background in WPF DOCX Editor
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) control allows you to change background color of the control. A background of a control is represented by `Background` property of `SfRichTextBoxAdv` class. The default value of this property is black.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) control allows you to change background color of the control. A background of a control is represented by `Background` property of `SfRichTextBoxAdv` class. The default value of this property is black.
 
 The following code illustrates how to apply color as background to the document.
 
@@ -39,14 +39,14 @@ richTextBoxAdv.Background = New SolidColorBrush(Color.FromRgb(102, 153, 204))
 {% endtabs %}
 
 **Pages layout:**
-![Changing Background color of Page Layout in WPF RichTextBox](Image_images/wpf-richtextbox-page-layout-background.PNG)
+![Changing Background color of Page Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-page-layout-background.PNG)
 
 **Continuous layout:**
-![Changing Background color of Continuous Layout in WPF RichTextBox](Image_images/wpf-richtextbox-continuous-layout-background.PNG)
+![Changing Background color of Continuous Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-continuous-layout-background.PNG)
 
 **Block layout:**
 The block layout always inherits the control background color.
-![Changing Background color of Block Layout in WPF RichTextBox](Image_images/wpf-richtextbox-block-layout-background.PNG)
+![Changing Background color of Block Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-block-layout-background.PNG)
 
 ## How to override the document background in continuous layout type?
 By default, the document background properties will be applied when the `LayoutType` is continuous. You can suppress the document background and apply the control background by setting [`OverridesDocumentBackground`](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_OverridesDocumentBackground) property to true. The default value of this property is false.
@@ -89,11 +89,11 @@ richTextBoxAdv.OverridesDocumentBackground = true
 {% endtabs %}
 
 **Continuous layout:**
-![Changing Background color of Continuous Layout in WPF RichTextBox](Image_images/wpf-richtextbox-continous-background.PNG)
+![Changing Background color of Continuous Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-continous-background.PNG)
 
 ## Setting background for document pages
 
-The RichTextBox control allows you to change background color of the document pages. A background of a document is represented by [`Background`](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.DocumentAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_DocumentAdv_Background) property of `DocumentAdv` class. The default value of this property is white.
+The WPF DOCX Editor control allows you to change background color of the document pages. A background of a document is represented by [`Background`](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.DocumentAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_DocumentAdv_Background) property of `DocumentAdv` class. The default value of this property is white.
 
 N> 1. This API is supported starting from release version v17.4.0.39.
 N> 2. This property is independent for a document. So the background will change when the document is changed.
@@ -123,15 +123,15 @@ richTextBoxAdv.Document.Background.Color = Color.FromRgb(102, 153, 204)
 {% endtabs %}
 
 **Pages layout:**
-![Changing Background color of Page Layout in WPF RichTextBox](Image_images/wpf-richtextbox-pages-background.PNG)
+![Changing Background color of Page Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-pages-background.PNG)
 
 **Continuous layout:**
-![Changing Background color of Continuous Layout in WPF RichTextBox](Image_images/wpf-richtextbox-continous-background.PNG)
+![Changing Background color of Continuous Layout in WPF DOCX Editor](Image_images/wpf-richtextbox-continous-background.PNG)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Clipboard.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Clipboard.md
@@ -8,7 +8,7 @@ keywords: clipboard
 ---
 # Clipboard in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) takes advantage of the clipboard support and allows you to copy or paste contents to and from the clipboard in the following formats.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) takes advantage of the clipboard support and allows you to copy or paste contents to and from the clipboard in the following formats.
 
 * Rich text format.
 
@@ -36,10 +36,10 @@ The following code example demonstrates how to bind commands for accessing clipb
 
 N> In order to cut, copy, or paste, the standard keyboard shortcuts such as CTRL+X, CTRL+C, and CTRL+V can also be used.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Commands.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Commands.md
@@ -8,7 +8,7 @@ keywords: commands
 ---
 # Commands in WPF DOCX Editor
 
-Commands are a way to handle user interface (UI) actions. They are a loosely coupled way to bind the UI to the logic that performs the action. The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports commands for mostly used operations which are classified below.
+Commands are a way to handle user interface (UI) actions. They are a loosely coupled way to bind the UI to the logic that performs the action. The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports commands for mostly used operations which are classified below.
 
 * Character Formatting – Bold, Italic, Underline, Strike through, Baseline alignment, Font family, Font size, Font color and Highlight color.
 
@@ -1501,10 +1501,10 @@ The {{'[TextAlignment](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Con
 </tbody>
 </table>
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Selection in WPF RichTextBox](./Selection)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Selection in WPF DOCX Editor](./Selection)

--- a/Document-Processing/Word/Word-Processor/wpf/Comment.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Comment.md
@@ -8,8 +8,8 @@ keywords: comment
 ---
 # Comments in WPF DOCX Editor
 
-A Comment is a note or annotation that an author or reviewer can add to the document. The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports viewing and editing the comments in the document. It renders the comments present in the document in review pane, similar to the Microsoft Word.
-![WPF RichTextBox with Comment](Comment_images/wpf-richtextbox-comment.jpeg)
+A Comment is a note or annotation that an author or reviewer can add to the document. The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports viewing and editing the comments in the document. It renders the comments present in the document in review pane, similar to the Microsoft Word.
+![WPF DOCX Editor with Comment](Comment_images/wpf-richtextbox-comment.jpeg)
 
 N> Currently, the SfRichTextBoxAdv shows review pane only with Pages layout type.
 
@@ -116,7 +116,7 @@ End Sub
 
 {% endhighlight %}
 {% endtabs %}
-![Customizing Comment Style in WPF RichTextBox](Comment_images/wpf-richtextbox-comment-customization.jpeg)
+![Customizing Comment Style in WPF DOCX Editor](Comment_images/wpf-richtextbox-comment-customization.jpeg)
 
 ## Visibility of comment pane
 
@@ -137,10 +137,10 @@ Dim isCommentPaneVisible As Boolean = richTextBoxAdv.EditorSettings.IsCommentPan
 {% endhighlight %}
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Dialogs.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Dialogs.md
@@ -8,7 +8,7 @@ keywords: dialogs
 ---
 # Dialogs in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support for the following built-in dialogs similar to Microsoft Word application.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support for the following built-in dialogs similar to Microsoft Word application.
 
 * Font Dialog
 
@@ -281,10 +281,10 @@ End Class
 
 N> The same pattern can be followed to create custom windows for other dialogs such as Paragraph, List, Insert Table, Hyperlink, Find and Replace, Password, Table Properties, Table Options, Cell Options, Borders and Shading, and Styles. Replace the `FontDialog` control with the corresponding dialog control (e.g., `ParagraphDialog`, `ListDialog`, etc.).
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Document-Properties.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Document-Properties.md
@@ -10,7 +10,7 @@ keywords: Word count, paragraph count, page count, current page number.
 [WPF RichTexBox](https://www.syncfusion.com/wpf-controls/richtextbox) keep tracking the statistics about your documents. These statistics contains information about word count, paragraph count and pages count.
 
 ## Word count
-RichTextBox automatically counts the number of words in a document while you type. You can get the words count from [WordCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_WordCount) property. The default value of this property is 0. 
+WPF DOCX Editor automatically counts the number of words in a document while you type. You can get the words count from [WordCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_WordCount) property. The default value of this property is 0. 
 
 The following sample code demonstrates how to get the total number of words in the document.
 {% tabs %}
@@ -29,7 +29,7 @@ Dim wordCount As Integer = richTextBoxAdv.WordCount
 {% endtabs %}
 
 ## Paragraph count
-RichTextBox automatically counts the number of paragraphs in a document while you type. You can get the paragraph count from [ParagraphCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_ParagraphCount) property. The default value of this property is 0. Also, it ignores empty paragraphs.
+WPF DOCX Editor automatically counts the number of paragraphs in a document while you type. You can get the paragraph count from [ParagraphCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_ParagraphCount) property. The default value of this property is 0. Also, it ignores empty paragraphs.
 
 The following sample code demonstrates how to get the total number of paragraphs in the document.
 {% tabs %}
@@ -48,7 +48,7 @@ Dim paragraphCount As Integer = richTextBoxAdv.ParagraphCount
 {% endtabs %}
 
 ## Page count
-RichTextBox counts the number of pages in a document while you type. You can get the page count from [PageCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_PageCount) property. The default value of this property is 0.
+WPF DOCX Editor counts the number of pages in a document while you type. You can get the page count from [PageCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_PageCount) property. The default value of this property is 0.
 
 The following sample code demonstrates how to get the total number of pages in the document.
 {% tabs %}
@@ -73,7 +73,7 @@ End Sub
 {% endtabs %}
 
 ## Current page number
-The [CurrentPageNumber](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_CurrentPageNumber) property in the RichTextBox control returns the page number where the selection(cursor) is present.
+The [CurrentPageNumber](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_CurrentPageNumber) property in the WPF DOCX Editor control returns the page number where the selection(cursor) is present.
 
 The following sample code demonstrates how to get current page number in the document.
 
@@ -102,10 +102,10 @@ N> The above PageCount and CurrentPageNumber properties are not a dependency pro
 selection changed event.
 
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Document-Structure.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Document-Structure.md
@@ -8,12 +8,12 @@ keywords: document-structure
 ---
 # Document Structure in WPF DOCX Editor
 
-![Document Structure of WPF RichTextBox](Document-Structure_images/wpf-richtextbox-document-structure.jpeg)
+![Document Structure of WPF DOCX Editor](Document-Structure_images/wpf-richtextbox-document-structure.jpeg)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Document-Styles.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Document-Styles.md
@@ -10,7 +10,7 @@ keywords: styles
 # Document Styles in WPF DOCX Editor
 
 A style is a predefined set of table, numbering, paragraph, and character formatting properties that can be applied to regions within a document.
-In [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor), styles are created and added to a document programmatically or using the built-in Styles dialog.
+In [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor), styles are created and added to a document programmatically or using the built-in Styles dialog.
 
 A style in a document should have the following properties:
 
@@ -85,7 +85,7 @@ The following code example explains how to create new style dialog through comma
 {% endhighlight %}
 {% endtabs %}
 
-![WPF RichTextBox displays New Style Dialog](Image_images/wpf-richtextbox-new-style.PNG)
+![WPF DOCX Editor displays New Style Dialog](Image_images/wpf-richtextbox-new-style.PNG)
 
 ## Modify an existing style
 You can modify a style directly using the ShowStylesDialogCommand in SfRichTextBoxAdv.
@@ -98,10 +98,10 @@ The following code example explains how to modify the style dialog through comma
 {% endtabs %}
 
 From the styles list select a style you want to modify.
-![WPF RichTextBox displays Existing Styles](Image_images/wpf-richtextbox-existing-style.PNG)
+![WPF DOCX Editor displays Existing Styles](Image_images/wpf-richtextbox-existing-style.PNG)
 
 In the Formatting section, make any formatting changes you want, such as font style, size, or color, alignment, line spacing, or indentation.
-![WPF RichTextBox displays Modify Style](Image_images/wpf-richtextbox-modify-style.PNG)
+![WPF DOCX Editor displays Modify Style](Image_images/wpf-richtextbox-modify-style.PNG)
 
 ## Apply style
 The styles are applied using the ApplyStyleCommand in SfRichTextBoxAdv. The parameter should be passed is the Name of the Style.
@@ -127,10 +127,10 @@ The following code example explains how to clear the formatting of text through 
 {% endhighlight %}
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Properties in WPF RichTextBox](./Document-Properties)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-export-the-inserted-image-as-an-Embedded-image-in-HTML-in-SfRichTextBoxAdv.md
+++ b/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-export-the-inserted-image-as-an-Embedded-image-in-HTML-in-SfRichTextBoxAdv.md
@@ -9,7 +9,7 @@ keywords: embedded-image-html
 
 # How to Export Embedded Images in HTML in WPF DOCX Editor
 
-This page explains how to export the inserted image as an Embedded image in HTML in [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv).
+This page explains how to export the inserted image as an Embedded image in HTML in [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv).
 
 In the SfRichTextBoxAdv control, the control provides an option to specify HTML export settings. By utilizing the [ImageNodeVisited](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.ImageNodeVisitedEventArgs.html) event of the [HtmlImportExportSettings](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.HtmlImportExportSettings.html) instance, you can both retrieve and define the image stream and image source. When setting the image source as Empty, the inserted picture can be exported as an embedded image in the HTML.
 
@@ -40,5 +40,5 @@ richTextBoxAdv.HtmlImportExportSettings.ImageNodeVisited -= HtmlImportExportSett
 
 ## See also
 
-- [WPF RichTextBox Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
-- [WPF RichTextBox Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)
+- [WPF DOCX Editor Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
+- [WPF DOCX Editor Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)

--- a/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-identify-whether-the-viewer-is-scrolled-to-the-bottom-of-the-SfRichTextBoxAdv.md
+++ b/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-identify-whether-the-viewer-is-scrolled-to-the-bottom-of-the-SfRichTextBoxAdv.md
@@ -9,7 +9,7 @@ keywords: scroll-to-bottom
 
 # How to Detect Scrolling to the Bottom in WPF DOCX Editor
 
-This page explains how to identify whether the viewer is scrolled to the bottom in [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv).
+This page explains how to identify whether the viewer is scrolled to the bottom in [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv).
 
 SfRichTextBoxAdv scrollbars can be accessed through the [VerticalScrollBar](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_VerticalScrollBar) and [HorizontalScrollBar](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_HorizontalScrollBar) properties of [SfRichTextBoxAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html) class. Using these properties, you can identify when the document is scrolled to the bottom of the control. 
 
@@ -50,5 +50,5 @@ The following code example illustrates to identify whether the viewer is scrolle
 
 ## See also
 
-- [WPF RichTextBox Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
-- [WPF RichTextBox Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)
+- [WPF DOCX Editor Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
+- [WPF DOCX Editor Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)

--- a/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-paste-WordDocument-from-DocIO-in-SfRichTextBoxAdv.md
+++ b/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-paste-WordDocument-from-DocIO-in-SfRichTextBoxAdv.md
@@ -11,7 +11,7 @@ keywords: paste-WordDocument-from-DocIO
 
 The PasteCommand with [WordDocument](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.WordDocument.html) as a parameter is a feature that allows you to paste the contents of a WordDocument into the current selection of the SfRichTextBoxAdv control. This provides a convenient and efficient way to transfer and display complex document structures from Word documents directly within the SfRichTextBoxAdv.
 
-Using this feature, you can achieve the following by pasting WordDocument into the [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) at current selection:
+Using this feature, you can achieve the following by pasting WordDocument into the [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) at current selection:
 
 * Perform all the document manipulation features of [.NET Word library (DocIO)](https://help.syncfusion.com/file-formats/docio/overview) and then finally insert into SfRichTextBoxAdv
 
@@ -84,5 +84,5 @@ N> This feature is supported from v22.2.5.
 
 - [PasteCommand API Reference](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_PasteCommand)
 - [.NET Word Library (DocIO) Documentation](https://help.syncfusion.com/file-formats/docio/overview)
-- [WPF RichTextBox Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
-- [WPF RichTextBox Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)
+- [WPF DOCX Editor Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
+- [WPF DOCX Editor Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)

--- a/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-use-SfRichTextBoxAdv-as-a-standard-RichTextBox.md
+++ b/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/How-to-use-SfRichTextBoxAdv-as-a-standard-RichTextBox.md
@@ -116,5 +116,5 @@ N> [View Sample in GitHub](https://github.com/SyncfusionExamples/WPF-RichTextBox
 
 ## See also
 
-- [WPF RichTextBox Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
-- [WPF RichTextBox Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)
+- [WPF DOCX Editor Feature Tour](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor)
+- [WPF DOCX Editor Examples](https://github.com/syncfusion/docx-editor-sdk-wpf-demos)

--- a/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/Why-does-out-of-memory-exception-throw-on-opening-large-size-documents-in-SfRichTextBoxAdv.md
+++ b/Document-Processing/Word/Word-Processor/wpf/FAQ-Section/Why-does-out-of-memory-exception-throw-on-opening-large-size-documents-in-SfRichTextBoxAdv.md
@@ -9,7 +9,7 @@ keywords: out-of-memory-exception
 
 # Memory Issues with Large Documents in WPF DOCX Editor
 
-This page explains why an `OutOfMemoryException` is thrown when opening large documents in the [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control and provides guidance on how to avoid it.
+This page explains why an `OutOfMemoryException` is thrown when opening large documents in the [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control and provides guidance on how to avoid it.
 
 ## Cause
 

--- a/Document-Processing/Word/Word-Processor/wpf/Find-and-Replace.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Find-and-Replace.md
@@ -8,7 +8,7 @@ keywords: search,find,replace-text,find-options,regex-find
 ---
 # Find and Replace in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports searching text contents in the document. When combined with selection, it becomes a powerful tool for highlighting specific parts of the document, applying formatting such as bold, or replacing text. You can extend your search by using regular expressions to find a particular pattern of text in the document.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports searching text contents in the document. When combined with selection, it becomes a powerful tool for highlighting specific parts of the document, applying formatting such as bold, or replacing text. You can extend your search by using regular expressions to find a particular pattern of text in the document.
 
 The find and replace operations are exposed through the [Find](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_Find_System_String_Syncfusion_Windows_Controls_RichTextBoxAdv_FindOptions_), [FindAll](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_FindAll_System_String_Syncfusion_Windows_Controls_RichTextBoxAdv_FindOptions_), and [FindOptions](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.FindOptions.html) API members.
 
@@ -173,12 +173,12 @@ The following code example demonstrates how to show the options pane in SfRichTe
 {% endhighlight %}
 
 {% endtabs %}
-![WPF RichTextBox displays the Find option pane with the search input and navigation controls](Find-and-Replace_images/wpf-richtextbox-find-option.jpeg)
+![WPF DOCX Editor displays the Find option pane with the search input and navigation controls](Find-and-Replace_images/wpf-richtextbox-find-option.jpeg)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Getting-Started.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Getting-Started.md
@@ -9,9 +9,9 @@ keywords: getting started, docx editor
 
 # Getting Started with WPF DOCX Editor
 
-[WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) enables you to create, edit, view, and print Word documents in WPF applications. This section guides you through the steps to get started and create a RichTextBox in a WPF application.
+[WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) enables you to create, edit, view, and print Word documents in WPF applications. This section guides you through the steps to get started and create a DOCX Editor in a WPF application.
 
-## Create a RichTextBox in WPF using SfRichTextBoxAdv
+## Create a DOCX Editor in WPF using SfRichTextBoxAdv
 
 In this walkthrough, you will create a WPF application that uses the SfRichTextBoxAdv control.
 

--- a/Document-Processing/Word/Word-Processor/wpf/Getting-Started.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Getting-Started.md
@@ -9,7 +9,7 @@ keywords: getting started, docx editor
 
 # Getting Started with WPF DOCX Editor
 
-[WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) enables you to create, edit, view, and print Word documents in WPF applications. This section guides you through the steps to get started and create a RichTextBox in a WPF application.
+[WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) enables you to create, edit, view, and print Word documents in WPF applications. This section guides you through the steps to get started and create a RichTextBox in a WPF application.
 
 ## Create a RichTextBox in WPF using SfRichTextBoxAdv
 

--- a/Document-Processing/Word/Word-Processor/wpf/Hyperlink.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Hyperlink.md
@@ -8,7 +8,7 @@ keywords: hyperlink,insert-hyperlink,screen-tip,request-navigate
 ---
 # Hyperlinks in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports hyperlink fields similar to Microsoft Word. You can link part of the document content to the Internet, a file location, an email address, or any other text.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports hyperlink fields similar to Microsoft Word. You can link part of the document content to the Internet, a file location, an email address, or any other text.
 
 ## Insert hyperlink
 
@@ -156,7 +156,7 @@ paragraphAdv.Inlines.Add(New FieldEndAdv())
 {% endhighlight %}
 {% endtabs %}
 
-The following code example illustrates how to insert hyperlink field with ScreenTip into RichTextBox Document through UI command.
+The following code example illustrates how to insert hyperlink field with ScreenTip into WPF DOCX Editor Document through UI command.
 
 ### Insert with ScreenTip via UI command
 
@@ -169,7 +169,7 @@ SfRichTextBoxAdv.InsertHyperlinkCommand.Execute(new string[3] { "www.syncfusion.
 {% endhighlight %}
 {% endtabs %}
 
-The following section illustrates how to insert hyperlink field with ScreenTip in RichTextBox Document through built-in hyperlink dialog UI command like Microsoft Word application.
+The following section illustrates how to insert hyperlink field with ScreenTip in WPF DOCX Editor Document through built-in hyperlink dialog UI command like Microsoft Word application.
 1. Open insert hyperlink dialog.
 
 {% capture codesnippet1 %}
@@ -186,7 +186,7 @@ The following section illustrates how to insert hyperlink field with ScreenTip i
 2. Enter the display text, URL link and ScreenTip text.
 3. Click on OK to close the dialog box.
 
-![Adding Hyperlink to WPF RichTextBox](Hyperlink_images/wpf-richtextbox-insert-hyperlink.PNG)
+![Adding Hyperlink to WPF DOCX Editor](Hyperlink_images/wpf-richtextbox-insert-hyperlink.PNG)
 
 In the SfRichTextBoxAdv control, the ToolTip (ScreenTip) is shown by default when the mouse hovers over a hyperlink. You can disable the ToolTip by setting the [DisplayScreenTips](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.EditorSettings.html#Syncfusion_Windows_Controls_RichTextBoxAdv_EditorSettings_DisplayScreenTips) property of the [EditorSettings](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.EditorSettings.html) class. Set it to `false` to disable the ScreenTip; the default is `true`.
 
@@ -274,10 +274,10 @@ RemoveHandler richTextBoxAdv.RequestNavigate, AddressOf RichTextBoxAdv_RequestNa
 N> The available [HyperlinkType](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.HyperlinkType.html) values are `Webpage`, `Email`, `File` and  `Bookmark`. The [NavigationLink](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.Hyperlink.html#Syncfusion_Windows_Controls_RichTextBoxAdv_Hyperlink_NavigationLink) property contains the destination of the hyperlink as a string.
 
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Image.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Image.md
@@ -8,7 +8,7 @@ keywords: image,insert-picture,image-resizer,text-wrapping,image-position
 ---
 # Images in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to insert images of various formats, including bitmap (.bmp), JPEG (.jpg, .jpeg), and PNG (.png). Metafile images (.wmf, .emf) are not supported.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to insert images of various formats, including bitmap (.bmp), JPEG (.jpg, .jpeg), and PNG (.png). Metafile images (.wmf, .emf) are not supported.
 
 The following code example illustrates how to insert a picture into the SfRichTextBoxAdv document through the [InsertPictureCommand](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_InsertPictureCommand) UI command.
 
@@ -39,7 +39,7 @@ Dim richTextBoxAdv As New SfRichTextBoxAdv()
 richTextBoxAdv.EditorSettings.EnableImageResizer = False
 {% endhighlight %}
 {% endtabs %}
-![WPF RichTextBox showing an image selected with the built-in image resizer handles](Image_images/wpf-richtextbox-image.jpeg)
+![WPF DOCX Editor showing an image selected with the built-in image resizer handles](Image_images/wpf-richtextbox-image.jpeg)
 
 ## Text wrapping style
 Text wrapping refers to how images fit with surrounding text in a document. Please [refer to this page](/wpf/richtextbox/text-wrapping-style) for more information about text wrapping styles available in Word documents.
@@ -54,11 +54,11 @@ Starting from v19.1.0.x, the SfRichTextBoxAdv preserves the position properties 
 
 > **Behavior:** The image with text wrapping style `InLine` can only be dragged and dropped anywhere in the document.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Selection in WPF RichTextBox](Selection)
-- [Commands in WPF RichTextBox](Commands)
-- [Clipboard in WPF RichTextBox](Clipboard)
-- [Document Structure in WPF RichTextBox](Document-Structure)
+- [Selection in WPF DOCX Editor](Selection)
+- [Commands in WPF DOCX Editor](Commands)
+- [Clipboard in WPF DOCX Editor](Clipboard)
+- [Document Structure in WPF DOCX Editor](Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Import-and-Export.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Import-and-Export.md
@@ -8,7 +8,7 @@ keywords: import, export, load, save, async-load, document-events, file-formats
 ---
 # Import and Export in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to import or export Word documents (.docx, .doc), Rich Text Format documents (.rtf), HTML documents (.htm, .html), XAML documents (.xaml), and text documents (.txt). 
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to import or export Word documents (.docx, .doc), Rich Text Format documents (.rtf), HTML documents (.htm, .html), XAML documents (.xaml), and text documents (.txt). 
 
 The import and export operations are exposed through the [Load](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_Load_System_String_), [Save](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_Save_System_String_), [LoadAsync](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_LoadAsync_System_String_), and [SaveAsync](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_SaveAsync_System_String_) API members.
 
@@ -222,10 +222,10 @@ End Sub
 
 N> This API is supported starting from release version v18.2.0.X.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Clipboard in WPF RichTextBox](./Clipboard)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Clipboard in WPF DOCX Editor](./Clipboard)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Layout-Types.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Layout-Types.md
@@ -8,7 +8,7 @@ keywords: layout-types,pages,continuous,block,layout-type
 ---
 # Layout Types in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control allows you to choose between the following layout types through the [LayoutType](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_LayoutType) property. The default `LayoutType` is `Pages`.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control allows you to choose between the following layout types through the [LayoutType](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_LayoutType) property. The default `LayoutType` is `Pages`.
 
 * Pages
 
@@ -48,7 +48,7 @@ richTextBoxAdv.LayoutType = LayoutType.Pages
 
 {% endtabs %}
 
-![WPF RichTextBox rendered in Pages layout, showing paginated content](Layout-Types_images/wpf-richtextbox-page-layout.jpeg)
+![WPF DOCX Editor rendered in Pages layout, showing paginated content](Layout-Types_images/wpf-richtextbox-page-layout.jpeg)
 
 ## Continuous
 
@@ -79,7 +79,7 @@ richTextBoxAdv.LayoutType = LayoutType.Continuous
 
 {% endtabs %}
 
-![WPF RichTextBox rendered in Continuous layout, showing all content on a single scrollable page](Layout-Types_images/wpf-richtextbox-continuous-layout.jpeg)
+![WPF DOCX Editor rendered in Continuous layout, showing all content on a single scrollable page](Layout-Types_images/wpf-richtextbox-continuous-layout.jpeg)
 
 ## Block
 
@@ -110,12 +110,12 @@ richTextBoxAdv.LayoutType = LayoutType.Block
 
 {% endtabs %}
 
-![WPF RichTextBox rendered in Block layout, showing read-only rich-text content in a single block](Layout-Types_images/wpf-richtextbox-box-layout.jpeg)
+![WPF DOCX Editor rendered in Block layout, showing read-only rich-text content in a single block](Layout-Types_images/wpf-richtextbox-box-layout.jpeg)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Clipboard in WPF RichTextBox](./Clipboard)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Clipboard in WPF DOCX Editor](./Clipboard)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/List.md
+++ b/Document-Processing/Word/Word-Processor/wpf/List.md
@@ -8,7 +8,7 @@ keywords: list,numbered-list,bulleted-list,multilevel-list,list-format
 ---
 # List in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports both single-level and multilevel lists similar to those in Microsoft Word. Lists are used to organize data as step-by-step instructions in documents for easier understanding of key points. 
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports both single-level and multilevel lists similar to those in Microsoft Word. Lists are used to organize data as step-by-step instructions in documents for easier understanding of key points. 
 
 The list APIs are exposed through the [Lists](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.DocumentAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_DocumentAdv_Lists) and [AbstractLists](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.DocumentAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_DocumentAdv_AbstractLists) collections of the [DocumentAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.DocumentAdv.html) class, and the [LevelOverrideAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.LevelOverrideAdv.html) type. Up to **nine levels** can be defined in a multilevel list, matching the Microsoft Word limit.
 
@@ -31,10 +31,10 @@ The list style is determined by the [ListLevelPattern](https://help.syncfusion.c
 
 The character that appears between the list marker and the list text is set by the [FollowCharacter](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.FollowCharacterType.html) property of a list level. The available values are `Tab`, `Space`, and `Nothing`.
 The following screenshot shows single level bulleted list.
-![WPF RichTextBox showing a single-level bulleted list with dot bullets](List_images/wpf-richtextbox-bullet-list.jpeg)
+![WPF DOCX Editor showing a single-level bulleted list with dot bullets](List_images/wpf-richtextbox-bullet-list.jpeg)
 
 The following screenshot shows single level numbered list.
-![WPF RichTextBox showing a single-level numbered list with sequential numbers](List_images/wpf-richtextbox-number-list.jpeg)
+![WPF DOCX Editor showing a single-level numbered list with sequential numbers](List_images/wpf-richtextbox-number-list.jpeg)
 
 ## Multilevel List
 
@@ -43,7 +43,7 @@ Multilevel means defining a list within a list where up to nine levels can be de
 Each level of a multilevel list uses its own [ListLevelPattern](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.ListLevelPattern.html) value, so you can mix `Bullet` for one level, `Arabic` for another, and `LowLetter` for a third, as Microsoft Word does.
 
 The following screenshot shows multilevel list.
-![WPF RichTextBox showing a multilevel list with three indented levels, mixing bullet and number styles](List_images/wpf-richtextbox-multilevel-list.jpeg)
+![WPF DOCX Editor showing a multilevel list with three indented levels, mixing bullet and number styles](List_images/wpf-richtextbox-multilevel-list.jpeg)
 
 ## Adding List
 
@@ -361,10 +361,10 @@ richTextBoxAdv.Selection.ParagraphFormat.ListLevelNumber = 0
 {% endhighlight %}
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Selection in WPF RichTextBox](./Selection)
-- [Commands in WPF RichTextBox](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Selection in WPF DOCX Editor](./Selection)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Localization.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Localization.md
@@ -9,7 +9,7 @@ keywords: localization,resx,culture,current-ui-culture,resource-file
 ---
 # Localization in WPF DOCX Editor
 
-Localization is the process of adapting the application to a specific language. [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support to localize all the static text in the ribbon and its dialogs, including button labels, dialog titles, command tooltips, and menu items. Localization can be done by adding a resource file (Resx) and setting the desired culture in the application. The default culture is `en-US`.
+Localization is the process of adapting the application to a specific language. [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support to localize all the static text in the ribbon and its dialogs, including button labels, dialog titles, command tooltips, and menu items. Localization can be done by adding a resource file (Resx) and setting the desired culture in the application. The default culture is `en-US`.
 
 The default English (`en-US`) resource files (`Syncfusion.SfRichTextBoxAdv.WPF.resx` and `Syncfusion.SfRichTextRibbon.WPF.resx`) are embedded inside the `Syncfusion.SfRichTextBoxAdv.WPF` and `Syncfusion.SfRichTextRibbon.WPF` assemblies, so they are available without any additional setup.
 
@@ -74,10 +74,10 @@ The following screenshot shows the localization in the SfRichTextBoxAdv and SfRi
 
 ![SfRichTextBoxAdv and SfRichTextRibbon rendered with French-localized text in the ribbon and dialogs](Localization_images/wpf-richtextbox-localized-text.jpeg)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Getting Started in WPF RichTextBox](./Getting-Started)
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Getting Started in WPF DOCX Editor](./Getting-Started)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/MVVM.md
+++ b/Document-Processing/Word/Word-Processor/wpf/MVVM.md
@@ -8,7 +8,7 @@ keywords: mvvm,data-binding,dependency-property,two-way-binding,viewmodel
 ---
 # MVVM in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control can be used with the Model-View-ViewModel (MVVM) pattern. This section demonstrates how to use the SfRichTextBoxAdv control with the MVVM pattern.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control can be used with the Model-View-ViewModel (MVVM) pattern. This section demonstrates how to use the SfRichTextBoxAdv control with the MVVM pattern.
 
 ## Creating a view model
 
@@ -518,10 +518,10 @@ The following code example demonstrates how to create XAML view with SfRichTextB
 
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Layout Types in WPF RichTextBox](./Layout-Types)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Layout Types in WPF DOCX Editor](./Layout-Types)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Mini-Toolbar.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Mini-Toolbar.md
@@ -8,10 +8,10 @@ keywords: mini-toolbar,context-menu,formatting,floating-toolbar
 ---
 # Mini Toolbar in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports a built-in mini toolbar to provide rich text formatting options such as Bold, Italic, etc. The mini toolbar can be enabled or disabled through the [EnableMiniToolBar](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_EnableMiniToolBar) property. 
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports a built-in mini toolbar to provide rich text formatting options such as Bold, Italic, etc. The mini toolbar can be enabled or disabled through the [EnableMiniToolBar](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_EnableMiniToolBar) property. 
 
 The following screenshot shows the built-in mini toolbar of the SfRichTextBoxAdv control.
-![WPF RichTextBox showing the built-in mini toolbar with formatting options above a selected text range](Mini-Toolbar_images/wpf-richtextbox-mini-toolbar.jpeg)
+![WPF DOCX Editor showing the built-in mini toolbar with formatting options above a selected text range](Mini-Toolbar_images/wpf-richtextbox-mini-toolbar.jpeg)
 
 ## Enable/Disable mini toolbar
 
@@ -42,10 +42,10 @@ richTextBoxAdv.EnableMiniToolBar = False
 {% endhighlight %}
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Getting Started in WPF RichTextBox](./Getting-Started)
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Getting Started in WPF DOCX Editor](./Getting-Started)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Overview.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Overview.md
@@ -8,9 +8,9 @@ keywords: overview, richtextboxadv, sfrichtextboxadv
 ---
 # About Syncfusion WPF DOCX Editor Control
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) is a feature-rich, user-interactive control that enables viewing, editing, and printing rich text content with advanced formatting and layout capabilities, supporting elements such as text, images, tables, paragraphs, and comments. 
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) is a feature-rich, user-interactive control that enables viewing, editing, and printing rich text content with advanced formatting and layout capabilities, supporting elements such as text, images, tables, paragraphs, and comments. 
 
-![Output of WPF RichTextBox](./Overview_images/wpf-richtextbox.png)
+![Output of WPF DOCX Editor](./Overview_images/wpf-richtextbox.png)
 
 ## Features
 
@@ -25,4 +25,4 @@ The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor
 
 > **Limitation:** The SfRichTextBoxAdv cannot currently edit rich text in headers and footers.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool. 
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool. 

--- a/Document-Processing/Word/Word-Processor/wpf/Printing-Contents.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Printing-Contents.md
@@ -8,7 +8,7 @@ keywords: printing,print-dialog,print-completed,print-comments
 ---
 # Printing Contents in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports an API to print the rich text content as pages using the print dialog through the [PrintDocument](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_PrintDocument) method.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports an API to print the rich text content as pages using the print dialog through the [PrintDocument](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_PrintDocument) method.
 
 ## Print
 
@@ -103,10 +103,10 @@ richTextBoxAdv.EditorSettings.PrintComments = False
 
 N> In order to invoke printing, the standard keyboard shortcut CTRL + P can also be used.
 
-You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Getting Started in WPF RichTextBox](./Getting-Started)
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
+- [Getting Started in WPF DOCX Editor](./Getting-Started)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)

--- a/Document-Processing/Word/Word-Processor/wpf/Selection.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Selection.md
@@ -8,7 +8,7 @@ keywords: selection,cursor,selection-range,text-position,lost-focus,baseline-ali
 ---
 # Selection in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports selecting a portion of the document through UI interactions (mouse, touch, keyboard) or through the [Selection](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_Selection) API. A [TextPosition](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TextPosition.html) represents a position in the document as a paragraph instance plus an offset within that paragraph.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) supports selecting a portion of the document through UI interactions (mouse, touch, keyboard) or through the [Selection](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_Selection) API. A [TextPosition](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TextPosition.html) represents a position in the document as a paragraph instance plus an offset within that paragraph.
 The following sample code demonstrates how to retrieve the text position from the document using a paragraph instance and an offset value.
 {% tabs %}
 {% highlight c# %}
@@ -342,13 +342,13 @@ The following keyboard shortcuts are supported by SfRichTextBoxAdv for selection
 
 The SfRichTextBoxAdv control allows you to show the blinking cursor and selection highlight even when the control does not have focus. You can choose any one of the following selection visibility options:
 
-* **None** - Don't display neither caret nor selection highlight when the RichTextBox control does not have focus.
+* **None** - Don't display neither caret nor selection highlight when the WPF DOCX Editor control does not have focus.
 
-* **ShowCaret** - Displays the caret (blinking cursor) when the RichTextBox control does not have focus.
+* **ShowCaret** - Displays the caret (blinking cursor) when the WPF DOCX Editor control does not have focus.
 
-* **ShowSelection** - Displays the selection highlight when the RichTextBox control does not have focus.
+* **ShowSelection** - Displays the selection highlight when the WPF DOCX Editor control does not have focus.
 
-The following code example demonstrates how to display the selection highlight even when the RichTextBox control does not have focus.
+The following code example demonstrates how to display the selection highlight even when the WPF DOCX Editor control does not have focus.
 
 {% tabs %}
 {% highlight xaml %}
@@ -443,10 +443,10 @@ Dim isDeleted As Boolean = richTextBoxAdv.Selection.Delete()
 N> This API is supported starting from release version v18.2.0.X.
 
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Document Properties in WPF RichTextBox](./Document-Properties)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)

--- a/Document-Processing/Word/Word-Processor/wpf/Shapes.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Shapes.md
@@ -7,33 +7,33 @@ documentation: ug
 keywords: shapes, text-box
 ---
 # Shapes in WPF DOCX Editor
-Shapes are drawing objects that include a text box, rectangles, lines, curves, circles, etc. It can be preset or custom geometry. At present, [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) does not have support to insert shapes. however, if the document contains a shape while importing, it will be preserved properly.
+Shapes are drawing objects that include a text box, rectangles, lines, curves, circles, etc. It can be preset or custom geometry. At present, [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) does not have support to insert shapes. however, if the document contains a shape while importing, it will be preserved properly.
 
 N> Starting from v18.3.0.x, the shape preservation is supported.
 
 ## Supported shapes
-The RichTextBox has preservation support for the following shapes:
+The WPF DOCX Editor has preservation support for the following shapes:
 
 * Text box
 * Rectangle
 
-![List of supported shapes in RichTextBox](Shapes_images/Supported_Shapes.PNG)
+![List of supported shapes in WPF DOCX Editor](Shapes_images/Supported_Shapes.PNG)
 
 ## Text box shape
 A text box is a rectangular area on the document where you can enter text. When you click in a text box, a flashing cursor is displayed, indicating that you can begin typing. It allows you to enter multiple lines of text with rich text formatting.
 
-![Text box shape view in RichTextBox](Shapes_images/TextBox_Shape.PNG)
+![Text box shape view in WPF DOCX Editor](Shapes_images/TextBox_Shape.PNG)
 
 ## Shape resizer
-The RichTextBox also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer supports both touch and mouse interactions.
+The WPF DOCX Editor also supports a built-in shape resizer to resize the shapes present in the document. The shape resizer supports both touch and mouse interactions.
 
-![Shape resizer view in RichTextBox](Shapes_images/Shape_Resizer.PNG)
+![Shape resizer view in WPF DOCX Editor](Shapes_images/Shape_Resizer.PNG)
 
 ## Text wrapping style
 Text wrapping refers to how shapes fit with surrounding text in a document. Please [refer to this page](./Text-Wrapping-Style) for more information about text wrapping styles available in Word documents.
 
 ## Positioning the shape
-RichTextBox preserves the position properties of the shape and displays the shape based on position properties. It does not support modifying the position properties. If the shape is positioned relative to a line or paragraph, it moves automatically as text is edited.
+WPF DOCX Editor preserves the position properties of the shape and displays the shape based on position properties. It does not support modifying the position properties. If the shape is positioned relative to a line or paragraph, it moves automatically as text is edited.
 
 > **Limitation:** Currently, the shape with text wrapping style `In-Line with Text` can only be dragged and dropped anywhere in the document.
 
@@ -41,13 +41,13 @@ RichTextBox preserves the position properties of the shape and displays the shap
 > - Shape preservation is supported starting from v18.3.0.x.
 > - The position properties are preserved starting from v19.1.0.x.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Text Wrapping Style in WPF RichTextBox](./Text-Wrapping-Style)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Commands in WPF RichTextBox](./Commands)
+- [Text Wrapping Style in WPF DOCX Editor](./Text-Wrapping-Style)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)
 
 
 

--- a/Document-Processing/Word/Word-Processor/wpf/Spell-Check.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Spell-Check.md
@@ -8,7 +8,7 @@ keywords: spell-check,spelling,dictionary,multilingual,language
 ---
 # Spell Check in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support for checking spelling mistakes in the rich text document content through the [SpellChecker](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_SpellChecker) property of type [SpellChecker](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SpellChecker.html). It also supports enabling the following spell checking options.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides support for checking spelling mistakes in the rich text document content through the [SpellChecker](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SfRichTextBoxAdv.html#Syncfusion_Windows_Controls_RichTextBoxAdv_SfRichTextBoxAdv_SpellChecker) property of type [SpellChecker](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.SpellChecker.html). It also supports enabling the following spell checking options.
 
 * Ignore words in UPPERCASE.
 
@@ -120,12 +120,12 @@ The following code example demonstrates how to show the spelling pane in SfRichT
 {% endhighlight %}
 
 {% endtabs %}
-![WPF RichTextBox displays spellcheck option](SpellCheck_images/wpf-richtextbox-spellcheck-option.PNG)
+![WPF DOCX Editor displays spellcheck option](SpellCheck_images/wpf-richtextbox-spellcheck-option.PNG)
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Document Properties in WPF RichTextBox](./Document-Properties)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)

--- a/Document-Processing/Word/Word-Processor/wpf/Styles-and-Templates.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Styles-and-Templates.md
@@ -8,7 +8,7 @@ keywords: styles-and-templates,custom-style,theming,control-template,resource,xa
 ---
 # Styles and Templates in WPF DOCX Editor
 
-This section describes the styles and templates for the [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control. The Template defines the structure of the SfRichTextBoxAdv control and the Style defines its visual appearance. You can modify the default control template to define a unique appearance for the control.
+This section describes the styles and templates for the [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control. The Template defines the structure of the SfRichTextBoxAdv control and the Style defines its visual appearance. You can modify the default control template to define a unique appearance for the control.
 
 The following XAML shows the default style and template for the SfRichTextBoxAdv control.
 
@@ -835,10 +835,10 @@ The following code example demonstrates how to apply the custom style for SfRich
 
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Getting Started in WPF RichTextBox](./Getting-Started)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Commands in WPF RichTextBox](./Commands)
+- [Getting Started in WPF DOCX Editor](./Getting-Started)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Table.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Table.md
@@ -8,7 +8,7 @@ keywords: table,rows,columns,cells,merge,alignment
 ---
 # Tables in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to add tables to the rich text document. You can insert rows or columns into an existing table and can also delete existing rows and columns. The SfRichTextBoxAdv also allows you to merge the selected cells into one (both vertically and horizontally). The tables are represented using the [TableAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableAdv.html) class, with each row represented by [TableRowAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableRowAdv.html) and each cell by [TableCellAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableCellAdv.html). The cell-level layout is controlled by the [CellFormat](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.CellFormat.html) class.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) allows you to add tables to the rich text document. You can insert rows or columns into an existing table and can also delete existing rows and columns. The SfRichTextBoxAdv also allows you to merge the selected cells into one (both vertically and horizontally). The tables are represented using the [TableAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableAdv.html) class, with each row represented by [TableRowAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableRowAdv.html) and each cell by [TableCellAdv](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.TableCellAdv.html). The cell-level layout is controlled by the [CellFormat](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.CellFormat.html) class.
 
 The following code example illustrates how to add tables into the rich text document.
 
@@ -260,10 +260,10 @@ The following code example illustrates how to bind a button UI command for delet
 
 {% endtabs %}
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Document Properties in WPF RichTextBox](./Document-Properties)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)

--- a/Document-Processing/Word/Word-Processor/wpf/Text-Wrapping-Style.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Text-Wrapping-Style.md
@@ -7,41 +7,41 @@ documentation: ug
 keywords: text-wrapping,text-wrapping-style,inline,square,top-and-bottom,behind
 ---
 # Text Wrapping Style in WPF DOCX Editor
-Text wrapping refers to how images and shapes are fit with surrounding text in a document. Currently, [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) has only preservation support for image and textbox shape with below wrapping styles.
+Text wrapping refers to how images and shapes are fit with surrounding text in a document. Currently, [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) has only preservation support for image and textbox shape with below wrapping styles.
 
 ## In-Line with Text
 In this option, the image or shape is placed on the same line as the surrounding text, like any other word or letter. The image or shape moves automatically with the text as you edit, whereas the other options denote that the image or shape stays in a fixed position while the text shifts and wraps around it.
 
-![view of image with inline wrapping style in RichTextBox](Text-Wrapping-Style_images/inline-textwrapping.PNG)
+![view of image with inline wrapping style in WPF DOCX Editor](Text-Wrapping-Style_images/inline-textwrapping.PNG)
 
 ## Behind
 In this option, the image or shape is placed behind the text. This can be used when you need to add a watermark or background image to a document.
 
-![view of image with behind wrapping style in RichTextBox](Text-Wrapping-Style_images/behind-textwrapping.PNG)
+![view of image with behind wrapping style in WPF DOCX Editor](Text-Wrapping-Style_images/behind-textwrapping.PNG)
 
 ## In Front of Text
 In this option, the image or shape is placed in front of the text. This can be used to place an image around some text or to add a shape that highlights part of a paragraph.
 
-![view of image with in front of text wrapping style in RichTextBox](Text-Wrapping-Style_images/infront-textwrapping.PNG)
+![view of image with in front of text wrapping style in WPF DOCX Editor](Text-Wrapping-Style_images/infront-textwrapping.PNG)
 
 ## Top and Bottom
 In this option, the text wraps above and below the image or shape. No text appears to the left or right of the image or shape. This can be used for larger images or shapes that occupy most of the width in a document.
 
-![view of image with top and bottom wrapping style in RichTextBox](Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
+![view of image with top and bottom wrapping style in WPF DOCX Editor](Text-Wrapping-Style_images/topandbottom-textwrapping.PNG)
 
 ## Square
 In this option, Text wraps around the image or text box in a square shape.
 
-![view of shape with square wrapping style in RichTextBox](Text-Wrapping-Style_images/square-textwrapping.PNG)
+![view of shape with square wrapping style in WPF DOCX Editor](Text-Wrapping-Style_images/square-textwrapping.PNG)
 
 N> 1. The in front of and behind text wrapping styles are supported starting from v18.3.0.x
 N> 2. The top and bottom wrapping style is supported starting from v19.1.0.x
 N> 3. The Tight and Through styles are displayed like the square wrapping style starting from v19.2.0.x.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Shapes in WPF RichTextBox](./Shapes)
-- [Image in WPF RichTextBox](./Image)
-- [Commands in WPF RichTextBox](./Commands)
+- [Shapes in WPF DOCX Editor](./Shapes)
+- [Image in WPF DOCX Editor](./Image)
+- [Commands in WPF DOCX Editor](./Commands)

--- a/Document-Processing/Word/Word-Processor/wpf/Undo-Redo.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Undo-Redo.md
@@ -8,7 +8,7 @@ keywords: undo-redo,history,undo,redo,editor-settings,is-undo-enabled
 ---
 # Undo Redo in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides history preservation support, which means each editing operation performed on its document content will be preserved in history. The undo and redo behavior is configured through the [EditorSettings](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.EditorSettings.html) class. You can easily undo any editing action. The undone actions will also be preserved in a separate stack enabling you to redo the action.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) provides history preservation support, which means each editing operation performed on its document content will be preserved in history. The undo and redo behavior is configured through the [EditorSettings](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.RichTextBoxAdv.EditorSettings.html) class. You can easily undo any editing action. The undone actions will also be preserved in a separate stack enabling you to redo the action.
 
 N> Currently, the number of actions that can be preserved in both undo and redo stacks is limited to 500.
 
@@ -99,10 +99,10 @@ richTextBoxAdv.EditorSettings.CanUndoStyle = False
 
 N> This API is supported starting from release version v18.1.0.X.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Commands in WPF RichTextBox](./Commands)
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Document Properties in WPF RichTextBox](./Document-Properties)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Document Properties in WPF DOCX Editor](./Document-Properties)

--- a/Document-Processing/Word/Word-Processor/wpf/Virtualization.md
+++ b/Document-Processing/Word/Word-Processor/wpf/Virtualization.md
@@ -8,12 +8,12 @@ keywords: virtualization,ui-virtualization,performance,scrolling
 ---
 # Virtualization in WPF DOCX Editor
 
-The [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports UI virtualization. UI elements are created only for the contents that are visible in the viewer. The UI elements are created for the contents that become visible while scrolling the viewer. This reduces memory utilization and improves UI performance.
+The [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) (SfRichTextBoxAdv) control supports UI virtualization. UI elements are created only for the contents that are visible in the viewer. The UI elements are created for the contents that become visible while scrolling the viewer. This reduces memory utilization and improves UI performance.
 
-N> You can refer to our [WPF RichTextBox](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF RichTextBox example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
+N> You can refer to our [WPF DOCX Editor](https://www.syncfusion.com/docx-editor-sdk/wpf-docx-editor) feature tour page for its groundbreaking feature representations. You can also explore our [WPF DOCX Editor example](https://github.com/syncfusion/docx-editor-sdk-wpf-demos) to know how to render and configure the editing tool.
 
 ## See also
 
-- [Document Structure in WPF RichTextBox](./Document-Structure)
-- [Commands in WPF RichTextBox](./Commands)
-- [Getting Started in WPF RichTextBox](./Getting-Started)
+- [Document Structure in WPF DOCX Editor](./Document-Structure)
+- [Commands in WPF DOCX Editor](./Commands)
+- [Getting Started in WPF DOCX Editor](./Getting-Started)

--- a/Document-Processing/Word/Word-Processor/wpf/mcp.md
+++ b/Document-Processing/Word/Word-Processor/wpf/mcp.md
@@ -3,16 +3,16 @@ layout: post
 title: MCP Server for WPF DOCX Editor | Syncfusion
 description: The Syncfusion®WPF MCP Server provides setup guidance, integration support, and resources to accelerate WPF DOCX Editor development workflows.
 platform: document-processing
-control: RichTextBox
+control: WPF DOCX Editor
 documentation: ug
 ---
 # MCP Server for WPF DOCX Editor
 
-Syncfusion<sup style="font-size:70%">&reg;</sup> WPF MCP Server accelerates WPF RichTextBox application development by providing deep knowledge directly in your AI-powered IDE.[Model Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) integration enables quick access to documentation, API references, and code-generation features from within the development environment.
+Syncfusion<sup style="font-size:70%">&reg;</sup> WPF MCP Server accelerates WPF DOCX Editor application development by providing deep knowledge directly in your AI-powered IDE.[Model Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) integration enables quick access to documentation, API references, and code-generation features from within the development environment.
 
 ## Key Benefits
 
-- **Expert WPF RichTextBox (SfRichTextBoxAdv) Knowledge** - Deep understanding of Syncfusion WPF RichTextBox (SfRichTextBoxAdv) component and its implementation patterns.
+- **Expert WPF DOCX Editor (SfRichTextBoxAdv) Knowledge** - Deep understanding of Syncfusion WPF DOCX Editor (SfRichTextBoxAdv) component and its implementation patterns.
 - **Unlimited Usage** - No request limits, time restrictions, or query caps.
 - **Privacy-Focused** - The tools operate based on the user's query and do not store any content, data, or prompts.
 
@@ -25,7 +25,7 @@ Before beginning, ensure the following prerequisites are met:
 - Microsoft [.NET SDK 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later
 - A **compatible MCP client** (VS Code, Syncfusion<sup style="font-size:70%">&reg;</sup> Code Studio, Cursor, JetBrains, etc.)
 - An active [Syncfusion<sup style="font-size:70%">&reg;</sup> API key](https://syncfusion.com/account/api-key)
-- A **WPF application** (existing or new); see [ WPF application that includes Syncfusion WPF RichTextBox](https://help.syncfusion.com/document-processing/word/word-processor/wpf/getting-started)
+- A **WPF application** (existing or new); see [ WPF application that includes Syncfusion WPF DOCX Editor](https://help.syncfusion.com/document-processing/word/word-processor/wpf/getting-started)
 - An active Syncfusion<sup style="font-size:70%">&reg;</sup> license (any of the following):
   - [Commercial License](https://www.syncfusion.com/sales/unlimitedlicense)
   - [Free Community License](https://www.syncfusion.com/products/communitylicense)
@@ -172,11 +172,11 @@ You can install the Syncfusion WPF MCP Server as a local tool without requiring 
 
 ## Common use cases
 
-The examples below showcase how the `search_docs` tool handles real-world WPF RichTextBox development scenarios. The tool can be invoked directly, as shown in the examples below, for specific needs. Alternatively, an AI assistant can automatically invoke it based on the request.
+The examples below showcase how the `search_docs` tool handles real-world WPF DOCX Editor development scenarios. The tool can be invoked directly, as shown in the examples below, for specific needs. Alternatively, an AI assistant can automatically invoke it based on the request.
 
 **Get Started**
 
-Use `search_docs` to get contextual guidance, code snippets, and configuration examples for the WPF RichTextBox (SfRichTextBoxAdv) component.
+Use `search_docs` to get contextual guidance, code snippets, and configuration examples for the WPF DOCX Editor (SfRichTextBoxAdv) component.
 
 {% promptcards %}
 {% promptcard DOCX Editor Configuration %}
@@ -243,7 +243,7 @@ The table below lists frequently encountered issues and suggested resolutions to
 | **Incorrect API key config** | For the file path: verify file location and content. For inline key: check the key is correctly updated. |
 | **Wrong config file location** | VS Code: `.vscode/mcp.json` • Code Studio: `.codestudio/mcp.json` • Cursor: `.cursor/mcp.json` in the workspace root. |
 | **Check IDE logs** | VS Code / Code Studio: Output panel → "MCP" • Cursor: Developer Console for MCP errors. |
-| **WPF RichTextBox not rendering** | Ensure the `Syncfusion.SfRichTextBoxAdv.WPF` NuGet packages are installed and configured properly in MainWindow.xaml or MainWindow.xaml.cs |
+| **WPF DOCX Editor not rendering** | Ensure the `Syncfusion.SfRichTextBoxAdv.WPF` NuGet packages are installed and configured properly in MainWindow.xaml or MainWindow.xaml.cs |
 
 
 ## Privacy & Security

--- a/Document-Processing/Word/Word-Processor/wpf/ui-builder-skill.md
+++ b/Document-Processing/Word/Word-Processor/wpf/ui-builder-skill.md
@@ -149,18 +149,18 @@ Examples Prompts:
 
 {% promptcard Interactive Spell Check Editor %}
 
-Design a **RichTextBox control** as the main editing area. Place a toggle switch at the top-left corner of the application to control the spell check feature. When the toggle is turned **on**, enable spell checking in the RichTextBox. When the toggle is turned **off**, disable spell checking. Ensure the toggle reflects the current spell check state and updates the editor behavior in real time. 
+Design a **WPF DOCX Editor control** as the main editing area. Place a toggle switch at the top-left corner of the application to control the spell check feature. When the toggle is turned **on**, enable spell checking in the WPF DOCX Editor. When the toggle is turned **off**, disable spell checking. Ensure the toggle reflects the current spell check state and updates the editor behavior in real time. 
 
 {% endpromptcard %}
 
 {% promptcard Document Viewer Dashboard %}
 
-Design a document dashboard interface using a DataGrid and a RichTextBox control.
+Design a document dashboard interface using a DataGrid and a WPF DOCX Editor control.
 Create a DataGrid with two columns:
 - The first column should display document names (e.g., Document1.docx, Document2.docx).
 - The second column should contain a **View** button for each row.
 
-When the **View** button is clicked, load the corresponding document from the application's local assets folder into the RichTextBox for viewing.
+When the **View** button is clicked, load the corresponding document from the application's local assets folder into the WPF DOCX Editor for viewing.
 Ensure the interaction between the DataGrid and editor is seamless, and maintain a clean, simple layout suitable for browsing and viewing documents efficiently.
 
 {% endpromptcard %}


### PR DESCRIPTION
## Before
<img width="1197" height="862" alt="image" src="https://github.com/user-attachments/assets/875eaaa8-be93-46d5-aedf-ce11440d1f1d" />

